### PR TITLE
fix(export): resolve blank page issue on PDF export

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -162,7 +162,7 @@ abstract class PluginPdfCommon extends CommonGLPI
         if ($item instanceof CommonDBTM) {
             switch ($tab) {
                 case $item->getType() . '$main':
-                    $item::pdfMain($pdf, $item); // @phpstan-ignore-line - Call to an undefined static method CommonGLPI::pdfMain()
+                    static::pdfMain($pdf, $item); // @phpstan-ignore-line - Call to an undefined static method CommonGLPI::pdfMain()
                     break;
 
                 case 'Notepad$1':


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Revert line 165 in this PR : https://github.com/pluginsGLPI/pdf/pull/24

When I try to export an asset to a PDF file, the output is a blank page.

## Screenshots (if appropriate):

![Capture d’écran du 2025-04-24 15-03-47](https://github.com/user-attachments/assets/67a8268c-fcac-44a9-b4c0-4523f78d1590)

![Capture d’écran du 2025-04-24 15-04-26](https://github.com/user-attachments/assets/f2b175e4-705c-401c-a020-5f7715752bd2)

