### PR TITLE
fix(export): images missing in exported Knowledge Base PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+- Fix missing images in exported Knowledge Base PDFs
+
 ## [4.0.1] - 2025-03-10
 
 ### Added

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -85,8 +85,13 @@ class PluginPdfKnowbaseItem extends PluginPdfCommon
         foreach ($res as $img) {
             $docimg = new Document();
             $docimg->getFromDB((int) $img[2]);
+            $width = null;
 
-            $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
+            if (preg_match('/\bwidth=["\']?(\d+)/i', $img[0], $match_width)) {
+                $width = $match_width[1];
+            }
+
+            $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '" width="' . $width . '"/>';
             $answer = str_replace($img[0], $path, $answer);
         }
 

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -77,12 +77,18 @@ class PluginPdfKnowbaseItem extends PluginPdfCommon
             'UTF-8',
         )));
 
-        $answer
-        = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(html_entity_decode(
-            $item->getField('answer'),
-            ENT_QUOTES,
-            'UTF-8',
-        )));
+        $answer = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($item->getField('answer')));
+        $answer = preg_replace('#data:image/[^;]+;base64,#', '@', $answer);
+
+        preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $answer, $res, PREG_SET_ORDER);
+
+        foreach ($res as $img) {
+            $docimg = new Document();
+            $docimg->getFromDB((int) $img[2]);
+
+            $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
+            $answer = str_replace($img[0], $path, $answer);
+        }
 
         $pdf->setColumnsSize(100);
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37471
- Knowledge base article images were not exported to PDF

## Screenshots (if appropriate):

![Capture d’écran du 2025-04-24 16-51-44](https://github.com/user-attachments/assets/c6296b83-84c7-4475-8a18-2f74074fe393)

![Capture d’écran du 2025-04-24 16-54-44](https://github.com/user-attachments/assets/d8ba0dc3-f7ed-45c3-a062-6f61ef603de6)

![Capture d’écran du 2025-04-24 16-52-20](https://github.com/user-attachments/assets/9391e675-43b2-4154-af1c-856d197dda9e)


