### PR TITLE
Change signature of permissions check to comply with GLPI 11

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -67,12 +67,12 @@ class PluginPdfConfig extends CommonDBTM
     private static $_instance = null;
     public static $rightname  = 'config';
 
-    public static function canCreate()
+    public static function canCreate(): bool
     {
         return Session::haveRight('config', UPDATE);
     }
 
-    public static function canView()
+    public static function canView(): bool
     {
         return Session::haveRight('config', READ);
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.

## Description

- Here is a brief description of what this PR does
When migrating to GLPI 11 (now in beta), you get a Compile Error because the method signature for permission checks changed in GLPI 11 to force bool return. 
I'm not sure if the plugin works in GLPI 11 (and the setup's specifications doesn't permit it), but getting a Compile Error prevents it from disabling itself. So this PR isn't a full GLPI 11 compability, but it's a fix so that it doesn't crash when GLPI tries to load plugins.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/839028e4-cb3f-4f81-8147-de5554ada0dc)