### PR TITLE
formatNumber Cast currency value to float

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -377,7 +377,7 @@ class PluginPdfConfig extends CommonDBTM
         $currency = PluginPdfConfig::getInstance();
 
         $fmt = numfmt_create($language, NumberFormatter::CURRENCY);
-        $val = numfmt_format_currency($fmt, $value, $currency->getField('currency'));
+        $val = numfmt_format_currency($fmt, (float)$value, $currency->getField('currency'));
         foreach ($PDF_DEVICES as $option => $value) {
             if ($currency->fields['currency'] == $option) {
                 $sym = $value[1];

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -377,7 +377,7 @@ class PluginPdfConfig extends CommonDBTM
         $currency = PluginPdfConfig::getInstance();
 
         $fmt = numfmt_create($language, NumberFormatter::CURRENCY);
-        $val = numfmt_format_currency($fmt, (float)$value, $currency->getField('currency'));
+        $val = numfmt_format_currency($fmt, (float) $value, $currency->getField('currency'));
         foreach ($PDF_DEVICES as $option => $value) {
             if ($currency->fields['currency'] == $option) {
                 $sym = $value[1];


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes the issue of "Argument 2 ($amount) must be of type float, string given" when printing to PDF with the "Management" option checked
- It just casts the $value to float