### PR TITLE
Fix: html already decoded by displayText()

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -457,7 +457,7 @@ class PluginPdfTicket extends PluginPdfCommon
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('Title') . '</i></b>', $job->fields['name']),
         );
 
-        $content = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($job->fields['content']));
+        $content = $job->fields['content'];
 
         $content = preg_replace('#data:image/[^;]+;base64,#', '@', $content);
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
[- forum post ](https://forum.glpi-project.org/viewtopic.php?pid=519395#p519395)
- Here is a brief description of what this PR does
It avoid decoding twice html text, which breaks thins when "<" is used as it is interpreted as "tag opening".

