### PR TITLE
fix(pdf) Prevent nl2br from interfering with HTML table structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+### Fixed
+
+- Fixed table formatting and border in PDF
+
 ## [4.0.2] - 2025-09-30
 
 - Fix missing images in exported Knowledge Base PDFs

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -348,7 +348,7 @@ class PluginPdfSimplePDF
         $content = Glpi\RichText\RichText::getEnhancedHtml($text);
 
         // Split content by tables, keeping tables in the result
-        $segments = preg_split('/(<table[^>]*>.*?<\/table>)/s', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $segments = preg_split('/(<table\b[^>]*>.*?<\/table>)/is', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
         // Process segments and rebuild content
         $formatted_content = '';

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -353,7 +353,7 @@ class PluginPdfSimplePDF
         // Process segments and rebuild content
         $formatted_content = '';
         foreach ($segments as $segment) {
-            if (strpos($segment, '<table') !== false) {
+            if (str_contains($segment, '<table')) {
                 // Add border to tables if missing
                 if (!preg_match('/border\s*=\s*["\']?[1-9]/i', $segment)) {
                     $segment = preg_replace('/<table/i', '<table border="1"', $segment);

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -361,7 +361,7 @@ class PluginPdfSimplePDF
                 $formatted_content .= $segment;
             } else {
                 // Apply nl2br only to text segments
-                if (!preg_match("/<br\s?\/?>/", $segment) && !preg_match('/<p>/', $segment)) {
+                if (!str_contains($segment, '<br') && !str_contains($segment, '<p>')) {
                     $segment = nl2br($segment);
                 }
                 $formatted_content .= $segment;


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39537
- If a follow-up consists solely of a table, it is incorrectly formatted. Furthermore, when no border size is specified (as is the case when copying and pasting from Excel), the borders are not retained in the PDF.

## Screenshots (if appropriate):

Ticket:
<img width="588" height="862" alt="image" src="https://github.com/user-attachments/assets/0049c66b-e532-4547-80cd-54178b52fa13" />


Before:
<img width="356" height="578" alt="image" src="https://github.com/user-attachments/assets/be05c0f5-9688-4858-959f-f4efae4fe0c8" />

<img width="156" height="279" alt="image" src="https://github.com/user-attachments/assets/85ce287f-4830-4bea-9bd3-e6f56932cb7d" />

After:
<img width="480" height="1059" alt="image" src="https://github.com/user-attachments/assets/ace34a5b-f594-41a3-9d64-390a7ac3d6de" />


