### PR TITLE
Fix translation for "Observer"

### DIFF
--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -199,7 +199,7 @@ class PluginPdfChange extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Watcher'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -220,7 +220,7 @@ class PluginPdfChange extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Watcher group'),
+            __s('Observer group'),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -199,7 +199,7 @@ class PluginPdfChange extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', _n('Observer', 'Observers', 1), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -220,7 +220,7 @@ class PluginPdfChange extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Observer group'),
+            _n('Observer group', 'Observer groups', 1),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -71,7 +71,7 @@ class PluginPdfGroup extends PluginPdfCommon
             ),
             '<b><i>' . sprintf(
                 __s('%1$s - %2$s'),
-                __s('Observer') . '</i></b>',
+                _n('Observer', 'Observers', 1) . '</i></b>',
                 Dropdown::getYesNo($item->fields['is_watcher']),
             ),
             '<b><i>' . sprintf(

--- a/inc/group.class.php
+++ b/inc/group.class.php
@@ -71,7 +71,7 @@ class PluginPdfGroup extends PluginPdfCommon
             ),
             '<b><i>' . sprintf(
                 __s('%1$s - %2$s'),
-                __s('Watcher') . '</i></b>',
+                __s('Observer') . '</i></b>',
                 Dropdown::getYesNo($item->fields['is_watcher']),
             ),
             '<b><i>' . sprintf(

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -196,7 +196,7 @@ class PluginPdfProblem extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Watcher'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -217,7 +217,7 @@ class PluginPdfProblem extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Watcher group'),
+            __s('Observer group'),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -196,7 +196,7 @@ class PluginPdfProblem extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', _n('Observer', 'Observers', 1), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -217,7 +217,7 @@ class PluginPdfProblem extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Observer group'),
+            _n('Observer group', 'Observer groups', 1),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -355,7 +355,7 @@ class PluginPdfTicket extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Watcher'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -376,7 +376,7 @@ class PluginPdfTicket extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Watcher group'),
+            __s('Observer group'),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -355,7 +355,7 @@ class PluginPdfTicket extends PluginPdfCommon
         // Observer
         $users     = [];
         $listusers = '';
-        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Observer'), $listusers);
+        $watcher   = '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', _n('Observer', 'Observers', 1), $listusers);
         foreach ($job->getUsers(CommonITILActor::OBSERVER) as $d) {
             if ($d['users_id']) {
                 $tmp = Toolbox::stripTags($dbu->getUserName($d['users_id']));
@@ -376,7 +376,7 @@ class PluginPdfTicket extends PluginPdfCommon
         $listgroups   = '';
         $watchergroup = '<b><i>' . sprintf(
             __s('%1$s: %2$s') . '</i></b>',
-            __s('Observer group'),
+            _n('Observer group', 'Observer groups', 1),
             $listgroups,
         );
         foreach ($job->getGroups(CommonITILActor::OBSERVER) as $d) {


### PR DESCRIPTION
The correct string is 'Observer' instead of 'Watcher'.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does: The correct string is 'Observer' instead of 'Watcher' in GLPI translation files (``*.po``).

## Screenshots (if appropriate):

As can be seen in screenshot below, the word "Watcher" and "Watcher group" isn't being translated to PT-BR.

<img width="471" height="482" alt="image" src="https://github.com/user-attachments/assets/0d400104-6bd9-4301-af75-212452e2d18a" />