### PR TITLE
fix(massiveaction): fix PDF export redirecting to item list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.1.3] - Unreleased
+
+### Fixed
+
+- Fix massive action PDF export redirecting to item list instead of generating the PDF
+
 ## [4.1.2] - 2026-01-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.1.3] - Unreleased
+## [Unreleased]
 
 ### Fixed
 

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -615,8 +615,8 @@ abstract class PluginPdfCommon extends CommonGLPI
                 }
                 $_SESSION['plugin_pdf']['type']   = $item->getType();
                 $_SESSION['plugin_pdf']['tab_id'] = serialize($tab_id);
-                echo "<script type='text/javascript'>
-                      location.href='" . $CFG_GLPI['root_doc'] . "/plugins/pdf/front/export.massive.php'</script>";
+                $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
+                $ma->setRedirect($CFG_GLPI['root_doc'] . '/plugins/pdf/front/export.massive.php');
                 break;
         }
     }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43434
- Here is a brief description of what this PR does
When using the “Export PDF” MassiveAction, the redirect to the PDF file may not occur. This fix removes the echo from the <script> tag and uses the setRedirect() method of the MassiveAction class to perform the redirect

## Screenshots (if appropriate):
