### PR TITLE
FIX / PDF export for assignable asset groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix image (field : description) in to pdf
 - Fix massive action PDF export redirecting to item list instead of generating the PDF
+- Fix PDF export for assignable asset groups by properly handling multiple groups
 
 ## [4.1.2] - 2026-01-08
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Glpi\\Tools\\": "../../tools/src/"
+            "Glpi\\Tools\\": "../../tools/src/",
+            "GlpiPlugin\\Pdf\\Tests\\": "tests/"
         }
     }
 }

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -37,40 +37,6 @@ abstract class PluginPdfCommon extends CommonGLPI
 
     public static $rightname = 'plugin_pdf';
 
-    protected static function get_label_value(string $label, mixed $value): string
-    {
-        return '<b><i>' . sprintf(__s('%1$s: %2$s'), $label . '</i></b>', $value);
-    }
-
-    protected static function get_dropdown_values(string $table, mixed $values): string
-    {
-        if (!is_array($values)) {
-            return Toolbox::stripTags(Dropdown::getDropdownName($table, $values));
-        }
-
-        $names = array_filter(array_map(
-            static fn($value) => Toolbox::stripTags(Dropdown::getDropdownName($table, $value)),
-            $values,
-        ));
-
-        return implode(', ', $names);
-    }
-
-    protected static function get_group_value(CommonGLPI $item, string $field = 'groups_id'): string
-    {
-        return self::get_dropdown_values('glpi_groups', $item->fields[$field] ?? []);
-    }
-
-    protected static function get_group_column(CommonGLPI $item, string $field = 'groups_id', ?string $label = null): string
-    {
-        return self::get_label_value($label ?? __s('Group'), self::get_group_value($item, $field));
-    }
-
-    protected static function display_group_line(PluginPdfSimplePDF $pdf, CommonGLPI $item, string $right_column): void
-    {
-        $pdf->displayLine(self::get_group_column($item), $right_column);
-    }
-
     /**
      * Constructor, should intialize $this->obj property
     **/
@@ -539,10 +505,35 @@ abstract class PluginPdfCommon extends CommonGLPI
                     ),
                 );
             case 'group-model':
+                $group_tech = Dropdown::getDropdownName(
+                    'glpi_groups',
+                    $item->fields['groups_id_tech'],
+                );
+                if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+                    $group_item = new Group_Item();
+                    $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+                    $group_ids = [];
+                    foreach ($groups as $group) {
+                        if ((int) $group->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
+                            $group_ids[] = (int) $group->fields['groups_id'];
+                        }
+                    }
+                    $group_names = array_filter(array_map(
+                        static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                        $group_ids,
+                    ));
+                    $group_tech = implode(', ', $group_names);
+                }
+
                 return $pdf->displayLine(
-                    self::get_group_column($item, 'groups_id_tech', __s('Group in charge of the hardware')),
-                    self::get_label_value(
-                        __s('Model'),
+                    '<b><i>' . sprintf(
+                        __s('%1$s: %2$s'),
+                        __s('Group in charge of the hardware') . '</i></b>',
+                        $group_tech,
+                    ),
+                    '<b><i>' . sprintf(
+                        __s('%1$s: %2$s'),
+                        __s('Model') . '</i></b>',
                         Toolbox::stripTags(Dropdown::getDropdownName(
                             'glpi_' . $type . 'models',
                             $item->fields[$type . 'models_id'],

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -39,10 +39,7 @@ abstract class PluginPdfCommon extends CommonGLPI
 
     public static $rightname = 'plugin_pdf';
 
-    /**
-     * @phpstan-suppress property.notFound
-     */
-    protected static function getGroupName(CommonGLPI $item, int $group_type = Group_Item::GROUP_TYPE_NORMAL): string
+    protected static function getGroupName(CommonDBTM $item, int $group_type = Group_Item::GROUP_TYPE_NORMAL): string
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
 

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -37,6 +37,40 @@ abstract class PluginPdfCommon extends CommonGLPI
 
     public static $rightname = 'plugin_pdf';
 
+    protected static function get_label_value(string $label, mixed $value): string
+    {
+        return '<b><i>' . sprintf(__s('%1$s: %2$s'), $label . '</i></b>', $value);
+    }
+
+    protected static function get_dropdown_values(string $table, mixed $values): string
+    {
+        if (!is_array($values)) {
+            return Toolbox::stripTags(Dropdown::getDropdownName($table, $values));
+        }
+
+        $names = array_filter(array_map(
+            static fn($value) => Toolbox::stripTags(Dropdown::getDropdownName($table, $value)),
+            $values,
+        ));
+
+        return implode(', ', $names);
+    }
+
+    protected static function get_group_value(CommonGLPI $item, string $field = 'groups_id'): string
+    {
+        return self::get_dropdown_values('glpi_groups', $item->fields[$field] ?? []);
+    }
+
+    protected static function get_group_column(CommonGLPI $item, string $field = 'groups_id', ?string $label = null): string
+    {
+        return self::get_label_value($label ?? __s('Group'), self::get_group_value($item, $field));
+    }
+
+    protected static function display_group_line(PluginPdfSimplePDF $pdf, CommonGLPI $item, string $right_column): void
+    {
+        $pdf->displayLine(self::get_group_column($item), $right_column);
+    }
+
     /**
      * Constructor, should intialize $this->obj property
     **/
@@ -506,17 +540,9 @@ abstract class PluginPdfCommon extends CommonGLPI
                 );
             case 'group-model':
                 return $pdf->displayLine(
-                    '<b><i>' . sprintf(
-                        __s('%1$s: %2$s'),
-                        __s('Group in charge of the hardware') . '</i></b>',
-                        Dropdown::getDropdownName(
-                            'glpi_groups',
-                            $item->fields['groups_id_tech'],
-                        ),
-                    ),
-                    '<b><i>' . sprintf(
-                        __s('%1$s: %2$s'),
-                        __s('Model') . '</i></b>',
+                    self::get_group_column($item, 'groups_id_tech', __s('Group in charge of the hardware')),
+                    self::get_label_value(
+                        __s('Model'),
                         Toolbox::stripTags(Dropdown::getDropdownName(
                             'glpi_' . $type . 'models',
                             $item->fields[$type . 'models_id'],

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;
@@ -43,19 +41,7 @@ abstract class PluginPdfCommon extends CommonGLPI
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
 
-        if (!Toolbox::hasTrait($item::class, AssignableItem::class)) {
-            return Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $item->fields[$field]));
-        }
-
-        $group_item = new Group_Item();
-        $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-
-        $group_ids = [];
-        foreach ($groups as $group) {
-            if ((int) $group->fields['type'] === $group_type) {
-                $group_ids[] = (int) $group->fields['groups_id'];
-            }
-        }
+        $group_ids = (array) ($item->fields[$field] ?? 0);
 
         return implode(', ', array_filter(array_map(
             static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -39,6 +39,9 @@ abstract class PluginPdfCommon extends CommonGLPI
 
     public static $rightname = 'plugin_pdf';
 
+    /**
+     * @phpstan-suppress property.notFound
+     */
     protected static function getGroupName(CommonGLPI $item, int $group_type = Group_Item::GROUP_TYPE_NORMAL): string
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -39,6 +39,30 @@ abstract class PluginPdfCommon extends CommonGLPI
 
     public static $rightname = 'plugin_pdf';
 
+    protected static function getGroupName(CommonGLPI $item, int $group_type = Group_Item::GROUP_TYPE_NORMAL): string
+    {
+        $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
+
+        if (!Toolbox::hasTrait($item::class, AssignableItem::class)) {
+            return Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $item->fields[$field]));
+        }
+
+        $group_item = new Group_Item();
+        $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+
+        $group_ids = [];
+        foreach ($groups as $group) {
+            if ((int) $group->fields['type'] === $group_type) {
+                $group_ids[] = (int) $group->fields['groups_id'];
+            }
+        }
+
+        return implode(', ', array_filter(array_map(
+            static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+            $group_ids,
+        )));
+    }
+
     /**
      * Constructor, should intialize $this->obj property
     **/
@@ -507,31 +531,11 @@ abstract class PluginPdfCommon extends CommonGLPI
                     ),
                 );
             case 'group-model':
-                $group_tech = Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $item->fields['groups_id_tech'],
-                );
-                if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
-                    $group_item = new Group_Item();
-                    $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-                    $group_ids = [];
-                    foreach ($groups as $group) {
-                        if ((int) $group->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
-                            $group_ids[] = (int) $group->fields['groups_id'];
-                        }
-                    }
-                    $group_names = array_filter(array_map(
-                        static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                        $group_ids,
-                    ));
-                    $group_tech = implode(', ', $group_names);
-                }
-
                 return $pdf->displayLine(
                     '<b><i>' . sprintf(
                         __s('%1$s: %2$s'),
                         __s('Group in charge of the hardware') . '</i></b>',
-                        $group_tech,
+                        self::getGroupName($item, Group_Item::GROUP_TYPE_TECH),
                     ),
                     '<b><i>' . sprintf(
                         __s('%1$s: %2$s'),

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;
@@ -509,7 +511,7 @@ abstract class PluginPdfCommon extends CommonGLPI
                     'glpi_groups',
                     $item->fields['groups_id_tech'],
                 );
-                if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+                if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
                     $group_item = new Group_Item();
                     $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
                     $group_ids = [];

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Glpi\Features\AssignableItemInterface;
+
 /**
  *  -------------------------------------------------------------------------
  *  LICENSE
@@ -29,7 +31,6 @@
  *             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  *  --------------------------------------------------------------------------
  */
-
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;
@@ -41,7 +42,7 @@ abstract class PluginPdfCommon extends CommonGLPI
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
 
-        if ($item instanceof \Glpi\Features\AssignableItemInterface) {
+        if ($item instanceof AssignableItemInterface) {
             // Many-to-many relation, stored in the glpi_groups_items pivot table
             global $DB;
             $it = $DB->request([

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -74,7 +74,6 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
-        // @phpstan-ignore-next-line function.impossibleType (itemtype is not always a class-string at runtime, despite CommonGLPI's phpdoc)
         if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -89,6 +89,7 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
+        // @phpstan-ignore-next-line function.impossibleType (itemtype is not always a class-string at runtime, despite CommonGLPI's phpdoc)
         if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItemInterface;
-
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;
@@ -43,23 +41,10 @@ abstract class PluginPdfCommon extends CommonGLPI
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
 
-        if ($item instanceof AssignableItemInterface) {
-            // Many-to-many relation, stored in the glpi_groups_items pivot table
-            global $DB;
-            $it = $DB->request([
-                'SELECT' => 'groups_id',
-                'FROM'   => Group_Item::getTable(),
-                'WHERE'  => [
-                    'itemtype' => $item::class,
-                    'items_id' => $item->getID(),
-                    'type'     => $group_type,
-                ],
-            ]);
-            $group_ids = array_column(iterator_to_array($it), 'groups_id');
-        } else {
-            // One-to-one relation, direct column on the item (e.g. glpi_itilcategories)
-            $group_ids = (array) ($item->fields[$field] ?? 0);
-        }
+        // $item->fields[$field] is already an array of group ids for items using the
+        // AssignableItem trait (many-to-many relation via glpi_groups_items), and a scalar
+        // group id for items using a direct one-to-one column (e.g. glpi_itilcategories).
+        $group_ids = (array) ($item->fields[$field] ?? 0);
 
         return implode(', ', array_filter(array_map(
             static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -1,7 +1,5 @@
 <?php
 
-use Glpi\Features\AssignableItemInterface;
-
 /**
  *  -------------------------------------------------------------------------
  *  LICENSE
@@ -31,6 +29,9 @@ use Glpi\Features\AssignableItemInterface;
  *             http://www.gnu.org/licenses/agpl-3.0-standalone.html
  *  --------------------------------------------------------------------------
  */
+
+use Glpi\Features\AssignableItemInterface;
+
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -41,7 +41,23 @@ abstract class PluginPdfCommon extends CommonGLPI
     {
         $field = $group_type === Group_Item::GROUP_TYPE_TECH ? 'groups_id_tech' : 'groups_id';
 
-        $group_ids = (array) ($item->fields[$field] ?? 0);
+        if ($item instanceof \Glpi\Features\AssignableItemInterface) {
+            // Many-to-many relation, stored in the glpi_groups_items pivot table
+            global $DB;
+            $it = $DB->request([
+                'SELECT' => 'groups_id',
+                'FROM'   => Group_Item::getTable(),
+                'WHERE'  => [
+                    'itemtype' => $item::class,
+                    'items_id' => $item->getID(),
+                    'type'     => $group_type,
+                ],
+            ]);
+            $group_ids = array_column(iterator_to_array($it), 'groups_id');
+        } else {
+            // One-to-one relation, direct column on the item (e.g. glpi_itilcategories)
+            $group_ids = (array) ($item->fields[$field] ?? 0);
+        }
 
         return implode(', ', array_filter(array_map(
             static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfComputer extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -87,43 +85,16 @@ class PluginPdfComputer extends PluginPdfCommon
             ),
         );
 
-        $group = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id']);
-        $group_tech = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id_tech']);
-        if (Toolbox::hasTrait($computer::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($computer::class, (int) $computer->fields['id']);
-
-            $group_ids = [];
-            $group_tech_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
-                    $group_tech_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-            $group_tech = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_tech_ids,
-            )));
-        }
-
         $pdf->displayLine(
             '<b><i>' . sprintf(
                 __('%1$s: %2$s'),
                 __('Group') . '</i></b>',
-                $group,
+                self::getGroupName($computer),
             ),
             '<b><i>' . sprintf(
                 __('%1$s: %2$s'),
                 __('Group in charge of the hardware') . '</i></b>',
-                $group_tech,
+                self::getGroupName($computer, Group_Item::GROUP_TYPE_TECH),
             ),
         );
 

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -86,16 +86,11 @@ class PluginPdfComputer extends PluginPdfCommon
         );
 
         $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __('%1$s: %2$s'),
-                __('Group') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $computer->fields['groups_id'],
-                ),
-            ),
-            '<b><i>' . sprintf(__('%1$s: %2$s'), __('UUID') . '</i></b>', $computer->fields['uuid']),
+            self::get_group_column($computer),
+            self::get_group_column($computer, 'groups_id_tech', __('Group in charge of the hardware')),
         );
+
+        $pdf->displayLine(self::get_label_value(__('UUID'), $computer->fields['uuid']));
 
         $pdf->displayLine(
             '<b><i>' . sprintf(

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfComputer extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -87,7 +89,7 @@ class PluginPdfComputer extends PluginPdfCommon
 
         $group = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id']);
         $group_tech = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id_tech']);
-        if (Toolbox::hasTrait($computer::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($computer::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($computer::class, (int) $computer->fields['id']);
 

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -85,12 +85,53 @@ class PluginPdfComputer extends PluginPdfCommon
             ),
         );
 
+        $group = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id']);
+        $group_tech = Dropdown::getDropdownName('glpi_groups', $computer->fields['groups_id_tech']);
+        if (Toolbox::hasTrait($computer::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($computer::class, (int) $computer->fields['id']);
+
+            $group_ids = [];
+            $group_tech_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
+                    $group_tech_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+            $group_tech = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_tech_ids,
+            )));
+        }
+
         $pdf->displayLine(
-            self::get_group_column($computer),
-            self::get_group_column($computer, 'groups_id_tech', __('Group in charge of the hardware')),
+            '<b><i>' . sprintf(
+                __('%1$s: %2$s'),
+                __('Group') . '</i></b>',
+                $group,
+            ),
+            '<b><i>' . sprintf(
+                __('%1$s: %2$s'),
+                __('Group in charge of the hardware') . '</i></b>',
+                $group_tech,
+            ),
         );
 
-        $pdf->displayLine(self::get_label_value(__('UUID'), $computer->fields['uuid']));
+        $pdf->displayLine(
+            '<b><i>' . sprintf(
+                __('%1$s: %2$s'),
+                __('UUID') . '</i></b>',
+                $computer->fields['uuid'],
+            ),
+        );
 
         $pdf->displayLine(
             '<b><i>' . sprintf(

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -93,14 +93,6 @@ class PluginPdfComputer extends PluginPdfCommon
             ),
             '<b><i>' . sprintf(
                 __('%1$s: %2$s'),
-                __('Group in charge of the hardware') . '</i></b>',
-                self::getGroupName($computer, Group_Item::GROUP_TYPE_TECH),
-            ),
-        );
-
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __('%1$s: %2$s'),
                 __('UUID') . '</i></b>',
                 $computer->fields['uuid'],
             ),

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -60,10 +60,31 @@ class PluginPdfMonitor extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        self::display_group_line(
-            $pdf,
-            $item,
-            self::get_label_value(__s('Size'), sprintf(__s('%1$s %2$s'), $item->fields['size'], '"')),
+        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
+        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+
+            $group_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+        }
+
+        $pdf->displayLine(
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(
+                __s('%1$s: %2$s'),
+                __s('Size') . '</i></b>',
+                sprintf(__s('%1$s %2$s'), $item->fields['size'], '"'),
+            ),
         );
 
         $opts = ['have_micro'  => __s('Microphone'),

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -60,17 +60,10 @@ class PluginPdfMonitor extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']),
-            ),
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Size') . '</i></b>',
-                sprintf(__s('%1$s %2$s'), $item->fields['size'], '"'),
-            ),
+        self::display_group_line(
+            $pdf,
+            $item,
+            self::get_label_value(__s('Size'), sprintf(__s('%1$s %2$s'), $item->fields['size'], '"')),
         );
 
         $opts = ['have_micro'  => __s('Microphone'),

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfMonitor extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -62,26 +60,8 @@ class PluginPdfMonitor extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-
-            $group_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-        }
-
         $pdf->displayLine(
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', self::getGroupName($item)),
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Size') . '</i></b>',

--- a/inc/monitor.class.php
+++ b/inc/monitor.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfMonitor extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -61,7 +63,7 @@ class PluginPdfMonitor extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
         $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
 

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -82,11 +82,30 @@ class PluginPdfNetworkEquipment extends PluginPdfCommon
             ),
         );
 
+        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
+        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+
+            $group_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+        }
+
         $pdf->displayLine(
-            self::get_group_column($item),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
             '<b><i>' . __s('The MAC address and the IP of the equipment are included in an aggregated network port'),
-            self::get_label_value(
-                sprintf(__s('%1$s (%2$s)'), __s('Memory'), __s('Mio')),
+            '<b><i>' . sprintf(
+                __s('%1$s: %2$s'),
+                sprintf(__s('%1$s (%2$s)'), __s('Memory'), __s('Mio')) . '</i></b>',
                 $item->fields['ram'],
             ),
         );

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfNetworkEquipment extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -84,26 +82,8 @@ class PluginPdfNetworkEquipment extends PluginPdfCommon
             ),
         );
 
-        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-
-            $group_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-        }
-
         $pdf->displayLine(
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', self::getGroupName($item)),
             '<b><i>' . __s('The MAC address and the IP of the equipment are included in an aggregated network port'),
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -83,15 +83,10 @@ class PluginPdfNetworkEquipment extends PluginPdfCommon
         );
 
         $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']),
-            ),
+            self::get_group_column($item),
             '<b><i>' . __s('The MAC address and the IP of the equipment are included in an aggregated network port'),
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                sprintf(__s('%1$s (%2$s)'), __s('Memory'), __s('Mio')) . '</i></b>',
+            self::get_label_value(
+                sprintf(__s('%1$s (%2$s)'), __s('Memory'), __s('Mio')),
                 $item->fields['ram'],
             ),
         );

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfNetworkEquipment extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -83,7 +85,7 @@ class PluginPdfNetworkEquipment extends PluginPdfCommon
         );
 
         $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
 

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfPeripheral extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -64,26 +62,8 @@ class PluginPdfPeripheral extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-
-            $group_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-        }
-
         $pdf->displayLine(
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', self::getGroupName($item)),
             '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Brand') . '</i></b>', $item->fields['brand']),
         );
 

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -62,10 +62,27 @@ class PluginPdfPeripheral extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        self::display_group_line(
-            $pdf,
-            $item,
-            self::get_label_value(__s('Brand'), $item->fields['brand']),
+        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
+        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+
+            $group_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+        }
+
+        $pdf->displayLine(
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Brand') . '</i></b>', $item->fields['brand']),
         );
 
         $pdf->setColumnsSize(100);

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -62,13 +62,10 @@ class PluginPdfPeripheral extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'contact-otherserial');
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']),
-            ),
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Brand') . '</i></b>', $item->fields['brand']),
+        self::display_group_line(
+            $pdf,
+            $item,
+            self::get_label_value(__s('Brand'), $item->fields['brand']),
         );
 
         $pdf->setColumnsSize(100);

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfPeripheral extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -63,7 +65,7 @@ class PluginPdfPeripheral extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
         $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
 

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -63,17 +63,10 @@ class PluginPdfPhone extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
 
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']),
-            ),
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('UUID') . '</i></b>',
-                $item->fields['uuid'],
-            ),
+        self::display_group_line(
+            $pdf,
+            $item,
+            self::get_label_value(__s('UUID'), $item->fields['uuid']),
         );
 
         $pdf->displayLine(

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfPhone extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -65,26 +63,8 @@ class PluginPdfPhone extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
 
-        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
-
-            $group_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-        }
-
         $pdf->displayLine(
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', self::getGroupName($item)),
             '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('UUID') . '</i></b>', $item->fields['uuid']),
         );
 

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -63,10 +63,27 @@ class PluginPdfPhone extends PluginPdfCommon
         PluginPdfCommon::mainLine($pdf, $item, 'user-management');
 
 
-        self::display_group_line(
-            $pdf,
-            $item,
-            self::get_label_value(__s('UUID'), $item->fields['uuid']),
+        $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
+        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
+
+            $group_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+        }
+
+        $pdf->displayLine(
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('UUID') . '</i></b>', $item->fields['uuid']),
         );
 
         $pdf->displayLine(

--- a/inc/phone.class.php
+++ b/inc/phone.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfPhone extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -64,7 +66,7 @@ class PluginPdfPhone extends PluginPdfCommon
 
 
         $group = Dropdown::getDropdownName('glpi_groups', $item->fields['groups_id']);
-        if (Toolbox::hasTrait($item::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($item::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($item::class, (int) $item->fields['id']);
 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfPrinter extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -97,26 +95,8 @@ class PluginPdfPrinter extends PluginPdfCommon
             ),
         );
 
-        $group = Dropdown::getDropdownName('glpi_groups', $printer->fields['groups_id']);
-        if (Toolbox::hasTrait($printer::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($printer::class, (int) $printer->fields['id']);
-
-            $group_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-        }
-
         $pdf->displayLine(
-            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', self::getGroupName($printer)),
             '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('UUID') . '</i></b>', $printer->fields['uuid']),
         );
 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfPrinter extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -96,7 +98,7 @@ class PluginPdfPrinter extends PluginPdfCommon
         );
 
         $group = Dropdown::getDropdownName('glpi_groups', $printer->fields['groups_id']);
-        if (Toolbox::hasTrait($printer::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($printer::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($printer::class, (int) $printer->fields['id']);
 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -95,10 +95,27 @@ class PluginPdfPrinter extends PluginPdfCommon
             ),
         );
 
-        self::display_group_line(
-            $pdf,
-            $printer,
-            self::get_label_value(__s('UUID'), $printer->fields['uuid']),
+        $group = Dropdown::getDropdownName('glpi_groups', $printer->fields['groups_id']);
+        if (Toolbox::hasTrait($printer::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($printer::class, (int) $printer->fields['id']);
+
+            $group_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+        }
+
+        $pdf->displayLine(
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Group') . '</i></b>', $group),
+            '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('UUID') . '</i></b>', $printer->fields['uuid']),
         );
 
 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -95,17 +95,10 @@ class PluginPdfPrinter extends PluginPdfCommon
             ),
         );
 
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $printer->fields['groups_id']),
-            ),
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('UUID') . '</i></b>',
-                $printer->fields['uuid'],
-            ),
+        self::display_group_line(
+            $pdf,
+            $printer,
+            self::get_label_value(__s('UUID'), $printer->fields['uuid']),
         );
 
 

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -90,28 +90,14 @@ class PluginPdfSoftware extends PluginPdfCommon
         );
 
         $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group in charge of the hardware') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $software->fields['groups_id_tech'],
-                ),
-            ),
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('User') . '</i></b>',
+            self::get_group_column($software, 'groups_id_tech', __s('Group in charge of the hardware')),
+            self::get_label_value(
+                __s('User'),
                 $dbu->getUserName($software->fields['users_id']),
             ),
         );
 
-        $pdf->displayLine(
-            '<b><i>' . sprintf(
-                __s('%1$s: %2$s'),
-                __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id']),
-            ),
-        );
+        $pdf->displayLine(self::get_group_column($software));
 
         $pdf->displayLine(
             '<b><i>' . sprintf(

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -30,8 +30,6 @@
  *  --------------------------------------------------------------------------
  */
 
-use Glpi\Features\AssignableItem;
-
 class PluginPdfSoftware extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -91,38 +89,11 @@ class PluginPdfSoftware extends PluginPdfCommon
             ),
         );
 
-        $group = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id']);
-        $group_tech = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id_tech']);
-        if (Toolbox::hasTrait($software::class, AssignableItem::class)) {
-            $group_item = new Group_Item();
-            $groups = $group_item->getItemsAssociatedTo($software::class, (int) $software->fields['id']);
-
-            $group_ids = [];
-            $group_tech_ids = [];
-            foreach ($groups as $group_item_link) {
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
-                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
-                    $group_tech_ids[] = (int) $group_item_link->fields['groups_id'];
-                }
-            }
-
-            $group = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_ids,
-            )));
-            $group_tech = implode(', ', array_filter(array_map(
-                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
-                $group_tech_ids,
-            )));
-        }
-
         $pdf->displayLine(
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group in charge of the hardware') . '</i></b>',
-                $group_tech,
+                self::getGroupName($software, Group_Item::GROUP_TYPE_TECH),
             ),
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
@@ -135,7 +106,7 @@ class PluginPdfSoftware extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group') . '</i></b>',
-                $group,
+                self::getGroupName($software),
             ),
         );
 

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -89,15 +89,53 @@ class PluginPdfSoftware extends PluginPdfCommon
             ),
         );
 
+        $group = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id']);
+        $group_tech = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id_tech']);
+        if (Toolbox::hasTrait($software::class, \Glpi\Features\AssignableItem::class)) {
+            $group_item = new Group_Item();
+            $groups = $group_item->getItemsAssociatedTo($software::class, (int) $software->fields['id']);
+
+            $group_ids = [];
+            $group_tech_ids = [];
+            foreach ($groups as $group_item_link) {
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_NORMAL) {
+                    $group_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+                if ((int) $group_item_link->fields['type'] === Group_Item::GROUP_TYPE_TECH) {
+                    $group_tech_ids[] = (int) $group_item_link->fields['groups_id'];
+                }
+            }
+
+            $group = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_ids,
+            )));
+            $group_tech = implode(', ', array_filter(array_map(
+                static fn($group_id) => Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $group_id)),
+                $group_tech_ids,
+            )));
+        }
+
         $pdf->displayLine(
-            self::get_group_column($software, 'groups_id_tech', __s('Group in charge of the hardware')),
-            self::get_label_value(
-                __s('User'),
+            '<b><i>' . sprintf(
+                __s('%1$s: %2$s'),
+                __s('Group in charge of the hardware') . '</i></b>',
+                $group_tech,
+            ),
+            '<b><i>' . sprintf(
+                __s('%1$s: %2$s'),
+                __s('User') . '</i></b>',
                 $dbu->getUserName($software->fields['users_id']),
             ),
         );
 
-        $pdf->displayLine(self::get_group_column($software));
+        $pdf->displayLine(
+            '<b><i>' . sprintf(
+                __s('%1$s: %2$s'),
+                __s('Group') . '</i></b>',
+                $group,
+            ),
+        );
 
         $pdf->displayLine(
             '<b><i>' . sprintf(

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Features\AssignableItem;
+
 class PluginPdfSoftware extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -91,7 +93,7 @@ class PluginPdfSoftware extends PluginPdfCommon
 
         $group = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id']);
         $group_tech = Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id_tech']);
-        if (Toolbox::hasTrait($software::class, \Glpi\Features\AssignableItem::class)) {
+        if (Toolbox::hasTrait($software::class, AssignableItem::class)) {
             $group_item = new Group_Item();
             $groups = $group_item->getItemsAssociatedTo($software::class, (int) $software->fields['id']);
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/bootstrap.php" colors="true" testdox="true">
+   <testsuites>
+      <testsuite name="Tests">
+         <directory>tests</directory>
+      </testsuite>
+   </testsuites>
+</phpunit>

--- a/tests/Units/GetGroupNameTest.php
+++ b/tests/Units/GetGroupNameTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ *  -------------------------------------------------------------------------
+ *  LICENSE
+ *
+ *  This file is part of PDF plugin for GLPI.
+ *
+ *  PDF is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  PDF is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with Reports. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author    Nelly Mahu-Lasson, Remi Collet, Teclib
+ * @copyright Copyright (c) 2009-2022 PDF plugin team
+ * @license   AGPL License 3.0 or (at your option) any later version
+ * @link      https://github.com/pluginsGLPI/pdf/
+ * @link      http://www.glpi-project.org/
+ * @package   pdf
+ * @since     2009
+ *             http://www.gnu.org/licenses/agpl-3.0-standalone.html
+ *  --------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Pdf\Tests\Units;
+
+use Computer;
+use Glpi\Tests\DbTestCase;
+use Group;
+use Group_Item;
+use ITILCategory;
+use PluginPdfCommon;
+use ReflectionMethod;
+
+final class GetGroupNameTest extends DbTestCase
+{
+    private function getGroupName(\CommonDBTM $item, int $group_type = Group_Item::GROUP_TYPE_NORMAL): string
+    {
+        $method = new ReflectionMethod(PluginPdfCommon::class, 'getGroupName');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $item, $group_type);
+    }
+
+    /**
+     * One-to-one relation: the group id is stored directly in the `groups_id` column
+     * (e.g. glpi_itilcategories), as a scalar value.
+     */
+    public function testScalarGroupOnOneToOneRelation(): void
+    {
+        $group = $this->createItem(Group::class, [
+            'name'        => 'One-to-one group',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $category = $this->createItem(ITILCategory::class, [
+            'name'        => 'Category with a group',
+            'entities_id' => $this->getTestRootEntity(true),
+            'groups_id'   => $group->getID(),
+        ]);
+        $category->getFromDB($category->getID());
+
+        $this->assertSame($group->fields['name'], $this->getGroupName($category));
+    }
+
+    public function testNoGroupOnOneToOneRelation(): void
+    {
+        $category = $this->createItem(ITILCategory::class, [
+            'name'        => 'Category without a group',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $category->getFromDB($category->getID());
+
+        $this->assertSame('', $this->getGroupName($category));
+    }
+
+    /**
+     * Many-to-many relation: groups are stored in the `glpi_groups_items` pivot table
+     * (AssignableItem trait, e.g. glpi_computers), as an array of ids.
+     */
+    public function testArrayGroupsOnManyToManyRelation(): void
+    {
+        $group1 = $this->createItem(Group::class, [
+            'name'        => 'Computer group 1',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $group2 = $this->createItem(Group::class, [
+            'name'        => 'Computer group 2',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $tech_group = $this->createItem(Group::class, [
+            'name'        => 'Computer tech group',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $computer = $this->createItem(Computer::class, [
+            'name'            => 'Computer with groups',
+            'entities_id'     => $this->getTestRootEntity(true),
+            'groups_id'       => [$group1->getID(), $group2->getID()],
+            'groups_id_tech'  => [$tech_group->getID()],
+        ]);
+        $computer->getFromDB($computer->getID());
+
+        $this->assertSame(
+            implode(', ', [$group1->fields['name'], $group2->fields['name']]),
+            $this->getGroupName($computer)
+        );
+        $this->assertSame(
+            $tech_group->fields['name'],
+            $this->getGroupName($computer, Group_Item::GROUP_TYPE_TECH)
+        );
+    }
+
+    public function testNoGroupsOnManyToManyRelation(): void
+    {
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Computer without groups',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $computer->getFromDB($computer->getID());
+
+        $this->assertSame('', $this->getGroupName($computer));
+        $this->assertSame('', $this->getGroupName($computer, Group_Item::GROUP_TYPE_TECH));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ *  -------------------------------------------------------------------------
+ *  LICENSE
+ *
+ *  This file is part of PDF plugin for GLPI.
+ *
+ *  PDF is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  PDF is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with Reports. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author    Nelly Mahu-Lasson, Remi Collet, Teclib
+ * @copyright Copyright (c) 2009-2022 PDF plugin team
+ * @license   AGPL License 3.0 or (at your option) any later version
+ * @link      https://github.com/pluginsGLPI/pdf/
+ * @link      http://www.glpi-project.org/
+ * @package   pdf
+ * @since     2009
+ *             http://www.gnu.org/licenses/agpl-3.0-standalone.html
+ *  --------------------------------------------------------------------------
+ */
+
+require __DIR__ . '/../../../tests/bootstrap.php';
+
+if (!Plugin::isPluginActive('pdf')) {
+    throw new RuntimeException('Plugin pdf is not active in the test database');
+}


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43643 & !45124
- This PR fixes PDF exports for assignable GLPI assets when group fields are loaded as arrays of IDs. The PDF plugin was still assuming that `groups_id` and `groups_id_tech` were always scalar values, while GLPI now loads these fields from `glpi_groups_items` as arrays for assignable items. As a result, group-related fields could be empty or incorrectly rendered in generated PDFs.
The classes updated are the ones impacted beacause they correspond to assets implementing the AssignableItem feature.

## Screenshots :

Before fix : 

<img width="2294" height="699" alt="Capture d’écran du 2026-04-29 11-09-40" src="https://github.com/user-attachments/assets/dfef004b-aee6-4fbb-b6dd-868c332ea09c" />

<img width="772" height="355" alt="Capture d’écran du 2026-04-29 11-10-18" src="https://github.com/user-attachments/assets/76dbe44e-455f-4eb6-881f-ebd69f588deb" />


After fix : 

<img width="772" height="355" alt="Capture d’écran du 2026-04-29 11-10-45" src="https://github.com/user-attachments/assets/f980a7e6-b2ac-47c4-b978-b9241e23edb0" />

