### PR TITLE
Fix: prevent crash and warnings on items export for Problems and Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed table formatting and border in PDF
 - Fixed table cell size in PDF generation
+- Fixed PDF crash when exporting Problems with linked items lacking serial/inventory fields
+- Fixed PHP warnings flood when exporting Changes with linked items lacking serial/inventory fields
 
 ## [4.0.2] - 2025-09-30
 

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -130,8 +130,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
                                 Toolbox::stripTags(sprintf(__('%1$s: %2$s'), $typename, $nb)),
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags((string) $data["serial"]),
-                                Toolbox::stripTags((string) $data["otherserial"]),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         } else {
@@ -139,8 +139,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
                                 '',
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags((string) $data["serial"]),
-                                Toolbox::stripTags((string) $data["otherserial"]),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         }

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -132,8 +132,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 Toolbox::stripTags(sprintf(__('%1$s: %2$s'), $typename, $nb)),
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         } else {
@@ -141,8 +141,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 '',
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955
- Items linked to a Problem or Change may not have serial/otherserial columns (e.g. Software, User, Budget). Accessing these missing array keys caused a fatal TypeError in item_problem (crashing PDF generation) and a PHP warning flood in change_item. Use null-coalescing to default to an empty string.


_Also to be done in 11_