### PR TITLE
Fix: preserve HTML structure in Change and Problem description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed table formatting and border in PDF
 - Fixed table cell size in PDF generation
+- Fixed Change and Problem description exported as a single unstructured text block
 
 ## [4.0.2] - 2025-09-30
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -299,7 +299,7 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -299,7 +299,7 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('Description') . '</i></b>', ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955
- The description field (content) of Changes and Problems was passed through Toolbox::stripTags() before rendering, which removed all HTML structure generated by the rich text editor (paragraphs, lists, headings). The result was one undivided text block. Removing the strip call lets displayText() process the HTML natively via RichText::getEnhancedHtml().

## Screenshots (if appropriate):
