### PR TITLE
Fix: render Change analysis and plan fields as HTML in PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed table formatting and border in PDF
 - Fixed table cell size in PDF generation
+- Fixed Change analysis and plan fields rendering as raw HTML in PDF
 
 ## [4.0.2] - 2025-09-30
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -311,19 +311,15 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __('Analysis') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Impacts') . '</i></b>',
             $job->fields['impactcontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Control list') . '</i></b>',
             $job->fields['controlistcontent'],
-        ));
+        );
     }
 
     public static function pdfPlan(PluginPdfSimplePDF $pdf, Change $job)
@@ -331,25 +327,20 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __('Plans') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Deployment plan') . '</i></b>',
             $job->fields['rolloutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Backup plan') . '</i></b>',
             $job->fields['backoutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Checklist') . '</i></b>',
             $job->fields['checklistcontent'],
-        ));
+        );
     }
 
     public static function pdfStat(PluginPdfSimplePDF $pdf, Change $job)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- !43955
- It fixes the Change analysis (Impacts, Control list) and plan (Deployment plan, Backup plan, Checklist) fields rendering as raw HTML instead of formatted content in the exported PDF.
- The content fields were incorrectly passed as part of the label argument via `sprintf()`, preventing the PDF renderer from processing them as HTML. Each field is now passed as a dedicated content argument to `displayText()`.

## Screenshots (if appropriate):
