### PR TITLE
Fix: multiple HTML rendering and crash bugs in PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed table formatting and border in PDF
 - Fixed table cell size in PDF generation
+- Fixed approval comments rendering as raw HTML in PDF
+- Fixed PDF crash when exporting Problems with linked items lacking serial/inventory fields
+- Fixed PHP warnings flood when exporting Changes with linked items lacking serial/inventory fields
+- Fixed Change and Problem description exported as a single unstructured text block
+- Fixed Change analysis and plan fields rendering as raw HTML in PDF
 
 ## [4.0.2] - 2025-09-30
 

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -299,7 +299,7 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 
@@ -311,19 +311,15 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __('Analysis') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Impacts') . '</i></b>',
             $job->fields['impactcontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Control list') . '</i></b>',
             $job->fields['controlistcontent'],
-        ));
+        );
     }
 
     public static function pdfPlan(PluginPdfSimplePDF $pdf, Change $job)
@@ -331,25 +327,20 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __('Plans') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Deployment plan') . '</i></b>',
             $job->fields['rolloutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Backup plan') . '</i></b>',
             $job->fields['backoutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __('Checklist') . '</i></b>',
             $job->fields['checklistcontent'],
-        ));
+        );
     }
 
     public static function pdfStat(PluginPdfSimplePDF $pdf, Change $job)

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -130,8 +130,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
                                 Toolbox::stripTags(sprintf(__('%1$s: %2$s'), $typename, $nb)),
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags((string) $data["serial"]),
-                                Toolbox::stripTags((string) $data["otherserial"]),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         } else {
@@ -139,8 +139,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
                                 '',
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags((string) $data["serial"]),
-                                Toolbox::stripTags((string) $data["otherserial"]),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         }

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -132,8 +132,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 Toolbox::stripTags(sprintf(__('%1$s: %2$s'), $typename, $nb)),
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         } else {
@@ -141,8 +141,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 '',
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -299,7 +299,7 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('Description') . '</i></b>', ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 

--- a/inc/ticketvalidation.class.php
+++ b/inc/ticketvalidation.class.php
@@ -81,7 +81,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
                 );
-                $tmp = trim($row['comment_submission']);
+                $tmp = trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8'));
                 $pdf->displayText('<b><i>' . sprintf(
                     __('%1$s: %2$s'),
                     __('Request comments') . '</i></b>',
@@ -89,7 +89,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                 ), (empty($tmp) ? __('None') : $tmp), 1);
 
                 if ($row['validation_date']) {
-                    $tmp = trim($row['comment_validation']);
+                    $tmp = trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8'));
                     $pdf->displayText(
                         '<b><i>' . sprintf(
                             __('%1$s: %2$s'),

--- a/tools/move_to_po.php
+++ b/tools/move_to_po.php
@@ -37,6 +37,7 @@
 
 chdir(dirname($_SERVER['SCRIPT_FILENAME']));
 
+$argv = $argv ?? [];
 for ($i = 1 ; $i < count($argv) ; $i++) {
     //To be able to use = in search filters, enter \= instead in command line
     //Replace the \= by ° not to match the split function


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955

- **TypeError crash** when exporting Problems or Changes with linked items that lack `serial`/`otherserial` columns (e.g. Software, User): fixed by using null-coalescing fallback before `Toolbox::stripTags()`.
- **Description rendered as a single block** in Problem and Change PDFs: `Toolbox::stripTags()` was stripping HTML structure before `displayText()`, which expects HTML. The strip call is removed.
- **Change analysis and plan fields showing raw HTML**: fields were embedded in the label argument via `sprintf()` instead of being passed as the content argument to `displayText()`. Fixed argument placement; also removed ineffective `setColumnsSize(10, 90)` calls before `displayText()` (which forces 100% internally).
- **Ticket approval comments showing HTML fragments**: comment fields were stored with HTML entities not decoded before PDF rendering. Fixed using `html_entity_decode()`.


_TODO: same PR on main_
