### PR TITLE
Fix: formatted text rendered as visible HTML tags in PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Change and Problem description exported as a single unstructured text block
 - Fixed Change analysis and plan fields rendering as raw HTML in PDF
 - Fixed rich text content rendered as visible HTML tags and unformatted text in PDF exports
+- Fixed Change approval comments rendering as visible HTML entities in PDF exports
+- Fixed Changes linked items showing phantom empty entries for users with broad entity access
 
 ## [4.0.2] - 2025-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed PHP warnings flood when exporting Changes with linked items lacking serial/inventory fields
 - Fixed Change and Problem description exported as a single unstructured text block
 - Fixed Change analysis and plan fields rendering as raw HTML in PDF
+- Fixed rich text content rendered as visible HTML tags and unformatted text in PDF exports
 
 ## [4.0.2] - 2025-09-30
 

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -91,8 +91,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
 
                     $query = ['FIELDS' => [$itemtable . '.*', 'glpi_changes_items.id AS IDD',
                         'glpi_entities.id AS entity'],
-                        'FROM'      => 'glpi_changes_items',
-                        'LEFT JOIN' => [$itemtable => ['FKEY' => [$itemtable => 'id',
+                        'FROM'       => 'glpi_changes_items',
+                        'INNER JOIN' => [$itemtable => ['FKEY' => [$itemtable => 'id',
                             'glpi_changes_items'                             => 'items_id'],
                             'glpi_changes_items.itemtype'   => $itemtype,
                             'glpi_changes_items.changes_id' => $instID]]];

--- a/inc/changevalidation.class.php
+++ b/inc/changevalidation.class.php
@@ -92,10 +92,10 @@ class PluginPdfChangeValidation extends PluginPdfCommon
                     TicketValidation::getStatus($row['status']),
                     Html::convDateTime($row['submission_date']),
                     $dbu->getUserName($row['users_id']),
-                    trim($row['comment_submission']),
+                    trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8')),
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
-                    trim($row['comment_validation']),
+                    trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8')),
                 );
             }
         }

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -344,11 +344,12 @@ class PluginPdfSimplePDF
         $save = [$this->cols, $this->colsx, $this->colsw, $this->align];
 
         $this->setColumnsSize(100);
-        $text    = $name . ' ' . $content;
-        $content = Glpi\RichText\RichText::getEnhancedHtml($text, ['text_maxsize' => 0]);
+        // Decode $content alone: mixing literal HTML from $name breaks isHtmlEncoded(), leaving GLPI entities (&#60;) un-decoded and visible as text in TCPDF.
+        $decoded = Glpi\RichText\RichText::getEnhancedHtml($content ?? '', ['text_maxsize' => 0]);
+        $text    = preg_replace('/<script\b[^>]*>.*?<\/script>/is', '', $name . ' ' . $decoded);
 
         // Split content by tables, keeping tables in the result
-        $segments = preg_split('/(<table\b[^>]*>.*?<\/table>)/is', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $segments = preg_split('/(<table\b[^>]*>.*?<\/table>)/is', $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
         // Process segments and rebuild content
         $formatted_content = '';


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955

GLPI-encoded content (`&#60;p&#62;`) was concatenated with the HTML label before `getEnhancedHtml()` processing in `displayText()`. The mixed string caused `Sanitizer::isHtmlEncoded()` to return false (literal `<>` in the label), skipping entity decoding. TCPDF then rendered `&#60;p&#62;` as visible text characters `<p>` instead of HTML paragraph tags, producing HTML fragments in the PDF and all text as a single unformatted block.

Fix: process `$content` separately through `getEnhancedHtml()` before concatenating with the label. Also strips residual `<script>` tags to prevent JavaScript code (e.g., from GLPI's "read more" wrapper) from appearing as visible text in the PDF.

## Screenshots (if appropriate):
