### PR TITLE
fix/pdf group and group technician

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix image (field : description) in to pdf
 - Fix massive action PDF export redirecting to item list instead of generating the PDF
+- Fix group and group technician display name
 
 ## [4.1.2] - 2026-01-08
 

--- a/inc/appliance.class.php
+++ b/inc/appliance.class.php
@@ -154,10 +154,7 @@ class PluginPdfAppliance extends PluginPdfCommon
             sprintf(
                 __s('%1$s: %2$s'),
                 '<b><i>' . __s('Group in charge of the hardware') . '</i></b>',
-                Toolbox::stripTags(Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $item->fields['groups_id_tech'],
-                )),
+                Toolbox::stripTags(PluginPdfCommon::getGroupDisplayName($item->fields['groups_id_tech'] ?? [], true)),
             ),
         );
 
@@ -183,10 +180,7 @@ class PluginPdfAppliance extends PluginPdfCommon
             sprintf(
                 __s('%1$s: %2$s'),
                 '<b><i>' . __s('Group') . '</i></b>',
-                Toolbox::stripTags(Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $item->fields['groups_id'],
-                )),
+                Toolbox::stripTags(PluginPdfCommon::getGroupDisplayName($item->fields['groups_id'] ?? [], true)),
             ),
         );
 

--- a/inc/cartridgeitem.class.php
+++ b/inc/cartridgeitem.class.php
@@ -95,10 +95,7 @@ class PluginPdfCartridgeItem extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group in charge of the hardware') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $cartitem->fields['groups_id_tech'],
-                ),
+                PluginPdfCommon::getGroupDisplayName($cartitem->fields['groups_id_tech'] ?? []),
             ),
         );
 

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -420,6 +420,26 @@ abstract class PluginPdfCommon extends CommonGLPI
         }
     }
 
+    // This helper accepts both formats: the old one (int) and the new one (array).
+    //This is for compatibility with other item types that do not use the AssignableItem trait.
+    public static function getGroupDisplayName(array|int $group_ids, bool $strip_tags = false): string
+    {
+        if (!is_array($group_ids)) {
+            $group_ids = $group_ids > 0 ? [$group_ids] : [];
+        }
+        $group_ids = array_filter(array_map('intval', $group_ids), static fn($id) => $id > 0);
+        if (empty($group_ids)) {
+            return Dropdown::getDropdownName('glpi_groups', 0);
+        }
+        $names = array_map(
+            static fn($id) => $strip_tags
+                ? Toolbox::stripTags(Dropdown::getDropdownName('glpi_groups', $id))
+                : Dropdown::getDropdownName('glpi_groups', $id),
+            $group_ids,
+        );
+        return implode(', ', $names);
+    }
+
     public static function mainTitle(PluginPdfSimplePDF $pdf, $item)
     {
         $pdf->setColumnsSize(50, 50);
@@ -509,10 +529,7 @@ abstract class PluginPdfCommon extends CommonGLPI
                     '<b><i>' . sprintf(
                         __s('%1$s: %2$s'),
                         __s('Group in charge of the hardware') . '</i></b>',
-                        Dropdown::getDropdownName(
-                            'glpi_groups',
-                            $item->fields['groups_id_tech'],
-                        ),
+                        self::getGroupDisplayName($item->fields['groups_id_tech'] ?? []),
                     ),
                     '<b><i>' . sprintf(
                         __s('%1$s: %2$s'),

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -429,7 +429,8 @@ abstract class PluginPdfCommon extends CommonGLPI
         }
         $group_ids = array_filter(array_map('intval', $group_ids), static fn($id) => $id > 0);
         if ($group_ids === []) {
-            return Dropdown::getDropdownName('glpi_groups', 0);
+            $name = Dropdown::getDropdownName('glpi_groups', 0);
+            return $strip_tags ? Toolbox::stripTags($name) : $name;
         }
         $names = array_map(
             static fn($id) => $strip_tags

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -59,7 +59,7 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
-        if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
+        if (($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {
                 $titles = [1 => $titles];
@@ -428,7 +428,7 @@ abstract class PluginPdfCommon extends CommonGLPI
             $group_ids = $group_ids > 0 ? [$group_ids] : [];
         }
         $group_ids = array_filter(array_map('intval', $group_ids), static fn($id) => $id > 0);
-        if (empty($group_ids)) {
+        if ($group_ids === []) {
             return Dropdown::getDropdownName('glpi_groups', 0);
         }
         $names = array_map(

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -89,10 +89,7 @@ class PluginPdfComputer extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __('%1$s: %2$s'),
                 __('Group') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $computer->fields['groups_id'],
-                ),
+                PluginPdfCommon::getGroupDisplayName($computer->fields['groups_id'] ?? []),
             ),
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('UUID') . '</i></b>', $computer->fields['uuid']),
         );

--- a/inc/consumableitem.class.php
+++ b/inc/consumableitem.class.php
@@ -84,10 +84,7 @@ class PluginPdfConsumableItem extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group in charge of the hardware') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $consitem->fields['groups_id_tech'],
-                ),
+                PluginPdfCommon::getGroupDisplayName($consitem->fields['groups_id_tech'] ?? []),
             ),
         );
 

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -94,7 +94,8 @@ class PluginPdfSoftware extends PluginPdfCommon
                 __s('%1$s: %2$s'),
                 __s('Group in charge of the hardware') . '</i></b>',
                 PluginPdfCommon::getGroupDisplayName(
-                    $software->fields['groups_id_tech'] ?? []),
+                    $software->fields['groups_id_tech'] ?? [],
+                ),
             ),
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),

--- a/inc/software.class.php
+++ b/inc/software.class.php
@@ -93,10 +93,8 @@ class PluginPdfSoftware extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group in charge of the hardware') . '</i></b>',
-                Dropdown::getDropdownName(
-                    'glpi_groups',
-                    $software->fields['groups_id_tech'],
-                ),
+                PluginPdfCommon::getGroupDisplayName(
+                    $software->fields['groups_id_tech'] ?? []),
             ),
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
@@ -109,7 +107,7 @@ class PluginPdfSoftware extends PluginPdfCommon
             '<b><i>' . sprintf(
                 __s('%1$s: %2$s'),
                 __s('Group') . '</i></b>',
-                Dropdown::getDropdownName('glpi_groups', $software->fields['groups_id']),
+                PluginPdfCommon::getGroupDisplayName($software->fields['groups_id'] ?? []),
             ),
         );
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45124
- When generating a PDF, the group and the technician group were identical.
groups_id and groups_id_tech are now arrays (AssignableItem type), rather than integers. A helper function, getGroupDisplayName(), has been added to handle both formats for compatibility.

## Screenshots (if appropriate):
<img width="668" height="356" alt="image" src="https://github.com/user-attachments/assets/a9c695db-49ea-4fd3-8906-d42cffa8ec38" />
<img width="496" height="225" alt="image" src="https://github.com/user-attachments/assets/e097fab2-1082-4417-a673-49fb7510dc5b" />

