### PR TITLE
Fix: restore image rendering in change/problem/task PDF descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix image rendering in Change/Problem descriptions and Problem task PDF exports
+
 ## [4.1.3] - 2026-06-24
 
 ### Fixed

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -298,7 +298,7 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Description'), ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -59,6 +59,8 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
+        // $itemtype has no native type hint; PHPDoc-inferred class-string type isn't enforced at runtime
+        /** @phpstan-ignore-next-line function.impossibleType */
         if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -298,7 +298,7 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Description') . '</i></b>', ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 

--- a/inc/problemtask.class.php
+++ b/inc/problemtask.class.php
@@ -124,7 +124,7 @@ class PluginPdfProblemTask extends PluginPdfCommon
                 );
                 $pdf->displayText(
                     '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Description'), ''),
-                    Toolbox::stripTags($data['content']),
+                    $data['content'],
                     1,
                 );
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44245
- `Toolbox::stripTags()` was stripping the `content` field before it reached the image-resolution logic in the PDF renderer, so embedded images displayed in Ticket PDF exports but not in Change/Problem descriptions or Problem task descriptions.
- This removes the stripping in those three places, aligning them with the pattern already used for Ticket, Followup and Solution PDF rendering.

## Screenshots (if appropriate):
