### PR TITLE
Fix: port pending fixes from 10.0 bugfix branch to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed approval comments rendering as raw HTML in PDF
+- Fixed PDF crash when exporting Problems with linked items lacking serial/inventory fields
+- Fixed Change and Problem description exported as a single unstructured text block
+- Fixed Change analysis and plan fields rendering as raw HTML in PDF
+- Fixed rich text content rendered as visible HTML tags and unformatted text in PDF exports
+- Fixed Change approval comments rendering as visible HTML entities in PDF exports
+- Fixed Changes linked items showing phantom empty entries for users with broad entity access
+
 ## [4.1.3] - 2026-06-24
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -298,7 +298,7 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__s('%1$s: %2$s') . '</i></b>', __s('Description'), ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 
@@ -310,19 +310,15 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __s('Analysis') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __s('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __s('Impacts') . '</i></b>',
             $job->fields['impactcontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __s('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __s('Control list') . '</i></b>',
             $job->fields['controlistcontent'],
-        ));
+        );
     }
 
     public static function pdfPlan(PluginPdfSimplePDF $pdf, Change $job)
@@ -330,25 +326,20 @@ class PluginPdfChange extends PluginPdfCommon
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __s('Plans') . '</b>');
 
-        $pdf->setColumnsSize(10, 90);
-
-        $pdf->displayText(sprintf(
-            __s('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __s('Deployment plan') . '</i></b>',
             $job->fields['rolloutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __s('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __s('Backup plan') . '</i></b>',
             $job->fields['backoutplancontent'],
-        ));
+        );
 
-        $pdf->displayText(sprintf(
-            __s('%1$s: %2$s'),
+        $pdf->displayText(
             '<b><i>' . __s('Checklist') . '</i></b>',
             $job->fields['checklistcontent'],
-        ));
+        );
     }
 
     public static function pdfStat(PluginPdfSimplePDF $pdf, Change $job)

--- a/inc/change_item.class.php
+++ b/inc/change_item.class.php
@@ -91,8 +91,8 @@ class PluginPdfChange_Item extends PluginPdfCommon
 
                     $query = ['FIELDS' => [$itemtable . '.*', 'glpi_changes_items.id AS IDD',
                         'glpi_entities.id AS entity'],
-                        'FROM'      => 'glpi_changes_items',
-                        'LEFT JOIN' => [$itemtable => ['FKEY' => [$itemtable => 'id',
+                        'FROM'       => 'glpi_changes_items',
+                        'INNER JOIN' => [$itemtable => ['FKEY' => [$itemtable => 'id',
                             'glpi_changes_items'                             => 'items_id'],
                             'glpi_changes_items.itemtype'   => $itemtype,
                             'glpi_changes_items.changes_id' => $instID]]];

--- a/inc/changevalidation.class.php
+++ b/inc/changevalidation.class.php
@@ -92,10 +92,10 @@ class PluginPdfChangeValidation extends PluginPdfCommon
                     TicketValidation::getStatus($row['status']),
                     Html::convDateTime($row['submission_date']),
                     $dbu->getUserName($row['users_id']),
-                    trim($row['comment_submission']),
+                    trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8')),
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
-                    trim($row['comment_validation']),
+                    trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8')),
                 );
             }
         }

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -59,6 +59,7 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
+        // @phpstan-ignore-next-line function.impossibleType - is_numeric() kept for parity with CommonGLPI::addStandardTab(), whose $itemtype PHPDoc type makes it always false
         if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {

--- a/inc/item_problem.class.php
+++ b/inc/item_problem.class.php
@@ -182,8 +182,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 Toolbox::stripTags(sprintf(__s('%1$s: %2$s'), $typename, $nb)),
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         } else {
@@ -191,8 +191,8 @@ class PluginPdfItem_Problem extends PluginPdfCommon
                                 '',
                                 Toolbox::stripTags($name),
                                 Dropdown::getDropdownName('glpi_entities', $data['entity']),
-                                Toolbox::stripTags($data['serial']),
-                                Toolbox::stripTags($data['otherserial']),
+                                Toolbox::stripTags($data['serial'] ?? ''),
+                                Toolbox::stripTags($data['otherserial'] ?? ''),
                                 $nb,
                             );
                         }

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -298,7 +298,7 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__s('%1$s: %2$s'), __s('Description') . '</i></b>', ''),
-            Toolbox::stripTags($job->fields['content']),
+            $job->fields['content'],
             1,
         );
 

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -345,8 +345,10 @@ class PluginPdfSimplePDF
         $save = [$this->cols, $this->colsx, $this->colsw, $this->align];
 
         $this->setColumnsSize(100);
-        $text    = $name . ' ' . $content;
-        $content = RichText::getEnhancedHtml($text, ['text_maxsize' => 0]);
+
+        // Decode $content alone: mixing literal HTML from $name breaks isHtmlEncoded(), leaving GLPI entities (&#60;) un-decoded and visible as text in TCPDF.
+        $decoded = RichText::getEnhancedHtml($content ?? '', ['text_maxsize' => 0]);
+        $content = preg_replace('/<script\b[^>]*>.*?<\/script>/is', '', $name . ' ' . $decoded);
 
         // Decode HTML entities BEFORE searching for images
         $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');

--- a/inc/ticketvalidation.class.php
+++ b/inc/ticketvalidation.class.php
@@ -80,7 +80,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
                 );
-                $tmp = trim($row['comment_submission']);
+                $tmp = trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8'));
                 $pdf->displayText('<b><i>' . sprintf(
                     __s('%1$s: %2$s'),
                     __s('Request comments') . '</i></b>',
@@ -88,7 +88,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                 ), (empty($tmp) ? __s('None') : $tmp), 1);
 
                 if ($row['validation_date']) {
-                    $tmp = trim($row['comment_validation']);
+                    $tmp = trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8'));
                     $pdf->displayText(
                         '<b><i>' . sprintf(
                             __s('%1$s: %2$s'),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44245
- Ports several fixes already merged on 10.0/bugfixes (PR #68 and #69) that were still missing from main.
- Approval comments and rich text content (change/problem description, analysis and plan fields) no longer render as raw or escaped HTML in PDF exports.
- PDF export of Problems no longer crashes when a linked item is missing serial or inventory number fields.
- Changes linked items no longer show phantom empty entries for users with broad entity access.

## Screenshots (if appropriate):
