### PR TITLE
Fix: restore image rendering in Problem task PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix image rendering in Problem task PDF exports
+
 ## [4.0.3] - 2026-06-30
 
 ### Fixed

--- a/inc/problemtask.class.php
+++ b/inc/problemtask.class.php
@@ -128,7 +128,7 @@ class PluginPdfProblemTask extends PluginPdfCommon
                 );
                 $pdf->displayText(
                     '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-                    Toolbox::stripTags($data['content']),
+                    $data['content'],
                     1,
                 );
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955
- `Toolbox::stripTags()` was still applied to the task content field in Problem task PDF exports, stripping `<img>` tags before `displayText()` could resolve them to local file paths.
- Change and Problem description exports were already fixed by earlier PRs (#68, #69); this restores the same fix for Problem task content.

## Screenshots (if appropriate):
