### PR TITLE
Fix/45471/images display in pdf exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+### Fixed
+
+- Fix images display in PDF: Make them display at their original position instead of at the end of the document.
+
 ## [4.1.3] - 2026-06-24
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -59,7 +59,6 @@ abstract class PluginPdfCommon extends CommonGLPI
             $withtemplate = $options['withtemplate'];
         }
 
-        // @phpstan-ignore-next-line function.impossibleType - is_numeric() kept for parity with CommonGLPI::addStandardTab(), whose $itemtype PHPDoc type makes it always false
         if (!is_numeric($itemtype) && ($obj = $dbu->getItemForItemtype($itemtype)) && (method_exists($itemtype, 'displayTabContentForPDF'))) {
             $titles = $obj->getTabNameForItem($this->obj, $withtemplate);
             if (!is_array($titles)) {

--- a/inc/knowbaseitem.class.php
+++ b/inc/knowbaseitem.class.php
@@ -107,7 +107,7 @@ class PluginPdfKnowbaseItem extends PluginPdfCommon
         );
         $pdf->displayLine(
             $dbu->getUserName($item->fields['users_id']),
-            Html::convDateTime($item->fields['date']),
+            Html::convDateTime($item->fields['date_creation']),
             Html::convDateTime($item->fields['date_mod']),
             Dropdown::getYesNo($item->fields['is_faq']),
             $item->fields['view'],

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -357,7 +357,7 @@ class PluginPdfSimplePDF
         $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
 
         preg_match_all(
-            '/<a\b[^>]*>.*?(<img\b[^>]*src=["\']([^"\']*docid=(\d+)[^"\']*)["\'][^>]*>).*?<\/a>/is',
+            '/<a\b[^>]*>\s*(<img\b[^>]*src=["\']([^"\']*docid=(\d+)[^"\']*)["\'][^>]*>)\s*<\/a>/i',
             $content,
             $matches,
             PREG_SET_ORDER,

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -152,7 +152,9 @@ class PluginPdfSimplePDF
     **/
     public function output($name = false)
     {
-        ob_clean();
+        if (ob_get_level() > 0) {
+            ob_clean();
+        }
         if (!$name) {
             return $this->pdf->Output('glpi.pdf', 'S');
         }

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -410,10 +410,8 @@ class PluginPdfSimplePDF
                         }
 
                         // Replace the original image by a properly resized one + remove the a tag
-                        if(file_exists($file_path)){
-                            $display_image_tag = '<img src="file://'. $file_path. '" width="' . $display_width . '" height="' . $display_height . '">';
-                            $content = str_replace($full_a_tag, $display_image_tag, $content);
-                        }
+                        $display_image_tag = '<img src="file://' . $file_path . '" width="' . $display_width . '" height="' . $display_height . '">';
+                        $content = str_replace($full_a_tag, $display_image_tag, $content);
                     }
                 }
             }

--- a/inc/simplepdf.class.php
+++ b/inc/simplepdf.class.php
@@ -152,6 +152,7 @@ class PluginPdfSimplePDF
     **/
     public function output($name = false)
     {
+        ob_clean();
         if (!$name) {
             return $this->pdf->Output('glpi.pdf', 'S');
         }
@@ -351,21 +352,19 @@ class PluginPdfSimplePDF
         // Decode HTML entities BEFORE searching for images
         $content = html_entity_decode($content, ENT_QUOTES, 'UTF-8');
 
-        // Extract images and remove from HTML - TCPDF will render them separately
         preg_match_all(
-            '/<img\b[^>]*src=["\']([^"\']*docid=(\d+)[^"\']*)["\'][^>]*>/i',
+            '/<a\b[^>]*>.*?(<img\b[^>]*src=["\']([^"\']*docid=(\d+)[^"\']*)["\'][^>]*>).*?<\/a>/is',
             $content,
             $matches,
             PREG_SET_ORDER,
         );
 
-        $images_to_display = [];
         if ($matches !== []) {
             $document = new Document();
             foreach ($matches as $match) {
-                $full_img_tag = $match[0];
-                $original_url = $match[1];
-                $docid = (int) $match[2];
+                $full_a_tag = $match[0];
+                $full_img_tag = $match[1];
+                $docid = (int) $match[3];
 
                 if ($document->getFromDB($docid) && isset($document->fields['filepath'])) {
                     $file_path = GLPI_DOC_DIR . '/' . $document->fields['filepath'];
@@ -410,15 +409,11 @@ class PluginPdfSimplePDF
                             $display_height = (int) ($display_height * $ratio);
                         }
 
-                        // Store image info for later insertion
-                        $images_to_display[] = [
-                            'tag' => $full_img_tag,
-                            'path' => $file_path,
-                            'width' => $display_width,
-                            'height' => $display_height,
-                        ];
-                        // Remove the img tag from HTML - we'll add images separately
-                        $content = str_replace($full_img_tag, '', $content);
+                        // Replace the original image by a properly resized one + remove the a tag
+                        if(file_exists($file_path)){
+                            $display_image_tag = '<img src="file://'. $file_path. '" width="' . $display_width . '" height="' . $display_height . '">';
+                            $content = str_replace($full_a_tag, $display_image_tag, $content);
+                        }
                     }
                 }
             }
@@ -444,13 +439,6 @@ class PluginPdfSimplePDF
         }
 
         $this->displayInternal(240, 0.5, self::LEFT, $minline * 5, [$formatted_content]);
-
-        // Now add extracted images after the text with their original dimensions
-        foreach ($images_to_display as $img_info) {
-            if (file_exists($img_info['path'])) {
-                $this->addPngFromFile($img_info['path'], $img_info['width'], $img_info['height']);
-            }
-        }
 
         /* Restore */
         [$this->cols, $this->colsx, $this->colsw, $this->align, ] = $save;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ parameters:
     parallel:
         maximumNumberOfProcesses: 2
     level: 5
+    treatPhpDocTypesAsCertain: false
     bootstrapFiles:
         - ../../stubs/glpi_constants.php
         - ../../vendor/autoload.php


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45471
- Here is a brief description of what this PR does
  - Change images display in pdf to make them appear at their original place, instead of at the end of the document
  - Fix  knowledge base's documents creation date not displaying in the table at the end
  - Fix some warning/error in the PHP logs

## Screenshots (if appropriate):
<img width="1023" height="864" alt="image" src="https://github.com/user-attachments/assets/ff98a696-a69e-4e4e-84c5-ec7ba9e34547" />
