### PR TITLE
Fix: restore inline images in PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix image rendering in Problem task PDF exports
+- Fix image rendering in Change and Problem description/task PDF exports
+- Fix image rendering in Change analysis/plan, Problem analysis and Ticket/Change approval comments PDF exports
+- Fix Problem analysis (impacts/causes/symptoms) rendered as raw HTML in PDF exports
 
 ## [4.0.3] - 2026-06-30
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/inc/change.class.php
+++ b/inc/change.class.php
@@ -299,7 +299,7 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-            $job->fields['content'],
+            self::resolveContentImages($job->fields['content']),
             1,
         );
 
@@ -313,12 +313,12 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . __('Impacts') . '</i></b>',
-            $job->fields['impactcontent'],
+            self::resolveContentImages($job->fields['impactcontent']),
         );
 
         $pdf->displayText(
             '<b><i>' . __('Control list') . '</i></b>',
-            $job->fields['controlistcontent'],
+            self::resolveContentImages($job->fields['controlistcontent']),
         );
     }
 
@@ -329,17 +329,17 @@ class PluginPdfChange extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . __('Deployment plan') . '</i></b>',
-            $job->fields['rolloutplancontent'],
+            self::resolveContentImages($job->fields['rolloutplancontent']),
         );
 
         $pdf->displayText(
             '<b><i>' . __('Backup plan') . '</i></b>',
-            $job->fields['backoutplancontent'],
+            self::resolveContentImages($job->fields['backoutplancontent']),
         );
 
         $pdf->displayText(
             '<b><i>' . __('Checklist') . '</i></b>',
-            $job->fields['checklistcontent'],
+            self::resolveContentImages($job->fields['checklistcontent']),
         );
     }
 

--- a/inc/changetask.class.php
+++ b/inc/changetask.class.php
@@ -121,7 +121,7 @@ class PluginPdfChangeTask extends PluginPdfCommon
                 );
                 $pdf->displayText(
                     '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-                    $data['content'],
+                    self::resolveContentImages($data['content']),
                     1,
                 );
             }

--- a/inc/changevalidation.class.php
+++ b/inc/changevalidation.class.php
@@ -92,10 +92,10 @@ class PluginPdfChangeValidation extends PluginPdfCommon
                     TicketValidation::getStatus($row['status']),
                     Html::convDateTime($row['submission_date']),
                     $dbu->getUserName($row['users_id']),
-                    trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8')),
+                    trim(self::resolveContentImages($row['comment_submission'] ?? '')),
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
-                    trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8')),
+                    trim(self::resolveContentImages($row['comment_validation'] ?? '')),
                 );
             }
         }

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -287,6 +287,31 @@ abstract class PluginPdfCommon extends CommonGLPI
     }
 
     /**
+     * Resolve inline images (docid-based src) to a local file:// path so TCPDF can load them.
+     *
+     * @param $content string raw HTML content (not yet unsanitized/decoded)
+     *
+     * @return string HTML content with resolved image paths
+    **/
+    protected static function resolveContentImages(string $content): string
+    {
+        $content = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($content));
+        $content = preg_replace('#data:image/[^;]+;base64,#', '@', $content);
+
+        preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $content, $res, PREG_SET_ORDER);
+
+        foreach ($res as $img) {
+            $docimg = new Document();
+            $docimg->getFromDB((int) $img[2]);
+
+            $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
+            $content = str_replace($img[0], $path, $content);
+        }
+
+        return $content;
+    }
+
+    /**
      * Read the object and create header for all pages
      *
      * No HTML supported in this function

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -103,22 +103,9 @@ class PluginPdfItilFollowup extends PluginPdfCommon
                 );
 
 
-                $content = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($data['content']));
-                $content = preg_replace('#data:image/[^;]+;base64,#', '@', $content);
-
-                preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $content, $res, PREG_SET_ORDER);
-
-                foreach ($res as $img) {
-                    $docimg = new Document();
-                    $docimg->getFromDB((int) $img[2]);
-
-                    $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
-                    $content = str_replace($img[0], $path, $content);
-                }
-
                 $pdf->displayText(
                     '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-                    $content,
+                    self::resolveContentImages($data['content']),
                     1,
                 );
             }

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -71,18 +71,7 @@ class PluginPdfITILSolution extends PluginPdfCommon
                 } else {
                     $title = __('Solution');
                 }
-                $sol = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($row['content']));
-                $sol = preg_replace('#data:image/[^;]+;base64,#', '@', $sol);
-
-                preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $sol, $res, PREG_SET_ORDER);
-
-                foreach ($res as $img) {
-                    $docimg = new Document();
-                    $docimg->getFromDB((int) $img[2]);
-
-                    $path = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
-                    $sol = str_replace($img[0], $path, $sol);
-                }
+                $sol = self::resolveContentImages($row['content']);
 
                 $text = $textapprove = '';
                 if ($row['status'] == 3) {

--- a/inc/problem.class.php
+++ b/inc/problem.class.php
@@ -299,7 +299,7 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('Description') . '</i></b>', ''),
-            $job->fields['content'],
+            self::resolveContentImages($job->fields['content']),
             1,
         );
 
@@ -315,36 +315,20 @@ class PluginPdfProblem extends PluginPdfCommon
 
         $text = '';
         if ($job->fields['impactcontent']) {
-            $text = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(
-                html_entity_decode(
-                    $job->getField('impactcontent'),
-                    ENT_QUOTES,
-                    'UTF-8',
-                ),
-            ));
+            $text = self::resolveContentImages($job->getField('impactcontent'));
         }
         $pdf->displayText('<b><i>' . sprintf(__('%1$s: %2$s'), __('Impacts') . '</i></b>', $text));
 
+        $text = '';
         if ($job->fields['causecontent']) {
-            $text = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(
-                html_entity_decode(
-                    $job->getField('causecontent'),
-                    ENT_QUOTES,
-                    'UTF-8',
-                ),
-            ));
+            $text = self::resolveContentImages($job->getField('causecontent'));
         }
 
         $pdf->displayText('<b><i>' . sprintf(__('%1$s: %2$s'), __('Causes') . '</i></b>', $text));
 
+        $text = '';
         if ($job->fields['symptomcontent']) {
-            $text = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(
-                html_entity_decode(
-                    $job->getField('symptomcontent'),
-                    ENT_QUOTES,
-                    'UTF-8',
-                ),
-            ));
+            $text = self::resolveContentImages($job->getField('symptomcontent'));
         }
 
         $pdf->displayText('<b><i>' . sprintf(__('%1$s: %2$s'), __('Symptoms') . '</i></b>', $text));

--- a/inc/problemtask.class.php
+++ b/inc/problemtask.class.php
@@ -128,7 +128,7 @@ class PluginPdfProblemTask extends PluginPdfCommon
                 );
                 $pdf->displayText(
                     '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-                    $data['content'],
+                    self::resolveContentImages($data['content']),
                     1,
                 );
             }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -457,23 +457,9 @@ class PluginPdfTicket extends PluginPdfCommon
             '<b><i>' . sprintf(__('%1$s: %2$s'), __('Title') . '</i></b>', $job->fields['name']),
         );
 
-        $content = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($job->fields['content']));
-
-        $content = preg_replace('#data:image/[^;]+;base64,#', '@', $content);
-
-        preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $content, $res, PREG_SET_ORDER);
-
-        foreach ($res as $img) {
-            $docimg = new Document();
-            $docimg->getFromDB((int) $img[2]);
-
-            $path    = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
-            $content = str_replace($img[0], $path, $content);
-        }
-
         $pdf->displayText(
             '<b><i>' . sprintf(__('%1$s: %2$s') . '</i></b>', __('Description'), ''),
-            $content,
+            self::resolveContentImages($job->fields['content']),
             1,
         );
 

--- a/inc/tickettask.class.php
+++ b/inc/tickettask.class.php
@@ -146,22 +146,9 @@ class PluginPdfTicketTask extends PluginPdfCommon
                     Toolbox::stripTags($dbu->getUserName($data['users_id'])),
                     $planification,
                 );
-                $content = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($data['content']));
-                $content = preg_replace('#data:image/[^;]+;base64,#', '@', $content);
-
-                preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $content, $res, PREG_SET_ORDER);
-
-                foreach ($res as $img) {
-                    $docimg = new Document();
-                    $docimg->getFromDB((int) $img[2]);
-
-                    $path = '<img src="file://' . GLPI_DOC_DIR . '/' . $docimg->fields['filepath'] . '"/>';
-                    $content = str_replace($img[0], $path, $content);
-                }
-
                 $pdf->displayText(
                     "<b><i>" . sprintf(__('%1$s: %2$s') . "</i></b>", __('Description'), ''),
-                    $content,
+                    self::resolveContentImages($data['content']),
                     1,
                 );
             }

--- a/inc/ticketvalidation.class.php
+++ b/inc/ticketvalidation.class.php
@@ -81,7 +81,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                     Html::convDateTime($row['validation_date']),
                     $dbu->getUserName($row['users_id_validate']),
                 );
-                $tmp = trim(html_entity_decode($row['comment_submission'] ?? '', ENT_QUOTES, 'UTF-8'));
+                $tmp = trim(self::resolveContentImages($row['comment_submission'] ?? ''));
                 $pdf->displayText('<b><i>' . sprintf(
                     __('%1$s: %2$s'),
                     __('Request comments') . '</i></b>',
@@ -89,7 +89,7 @@ class PluginPdfTicketValidation extends PluginPdfCommon
                 ), (empty($tmp) ? __('None') : $tmp), 1);
 
                 if ($row['validation_date']) {
-                    $tmp = trim(html_entity_decode($row['comment_validation'] ?? '', ENT_QUOTES, 'UTF-8'));
+                    $tmp = trim(self::resolveContentImages($row['comment_validation'] ?? ''));
                     $pdf->displayText(
                         '<b><i>' . sprintf(
                             __('%1$s: %2$s'),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43955
- Inline images embedded in Change and Problem descriptions, tasks, analysis fields, and in Ticket/Change approval comments were not resolved before rendering, so TCPDF could not load them and the images were silently missing from the exported PDF.
- This fix applies the same image resolution already used for Tickets and follow-ups to these remaining sections.

## Screenshots (if appropriate):
