### PR TITLE
Fix PDF export of tabs renamed in GLPI 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fix PDF export of tabs renamed in GLPI 11
+
 ## [4.1.4] - 2026-07-30
 
 ### Fixed

--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Asset\Asset_PeripheralAsset;
+
 abstract class PluginPdfCommon extends CommonGLPI
 {
     protected $obj = null;
@@ -180,7 +182,8 @@ abstract class PluginPdfCommon extends CommonGLPI
                     }
                     break;
 
-                case 'Ticket$1':
+                case 'Item_Ticket$1': // tab added on assets
+                case 'Ticket$1': // tab added on User, Group and SLA
                     if (Ticket::canView()) {
                         PluginPdfItem_Ticket::pdfForItem($pdf, $item);
                     }
@@ -230,8 +233,16 @@ abstract class PluginPdfCommon extends CommonGLPI
                     PluginPdfItem_Disk::pdfForItem($pdf, $item);
                     break;
 
-                case 'Computer_Item$1':
+                case Asset_PeripheralAsset::class . '$1':
                     PluginPdfComputer_Item::pdfForItem($pdf, $item);
+                    break;
+
+                case 'ItemAntivirus$1': // registered on Computer and Phone
+                    PluginPdfItemAntivirus::pdfForItem($pdf, $item);
+                    break;
+
+                case 'ItemVirtualMachine$1':
+                    PluginPdfItemVirtualMachine::pdfForItem($pdf, $item);
                     break;
 
                 case 'Item_SoftwareVersion$1':

--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -30,6 +30,8 @@
  *  --------------------------------------------------------------------------
  */
 
+use Glpi\Asset\Asset_PeripheralAsset;
+
 class PluginPdfComputer extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
@@ -188,15 +190,7 @@ class PluginPdfComputer extends PluginPdfCommon
     {
         if ($item instanceof Computer) {
             switch ($tab) {
-                case 'ComputerVirtualMachine$1':
-                    PluginPdfComputerVirtualMachine::pdfForComputer($pdf, $item);
-                    break;
-
-                case 'ComputerAntivirus$1':
-                    PluginPdfComputerAntivirus::pdfForComputer($pdf, $item);
-                    break;
-
-                case 'Computer_Item$1':
+                case Asset_PeripheralAsset::class . '$1':
                     PluginPdfComputer_Item::pdfForComputer($pdf, $item);
                     break;
 

--- a/inc/computer_item.class.php
+++ b/inc/computer_item.class.php
@@ -41,37 +41,33 @@ class PluginPdfComputer_Item extends PluginPdfCommon
         $this->obj = ($obj ?: new Asset_PeripheralAsset());
     }
 
-    public static function pdfForComputer(PluginPdfSimplePDF $pdf, Computer $comp)
+    public static function pdfForComputer(PluginPdfSimplePDF $pdf, CommonDBTM $comp)
     {
         /** @var DBmysql $DB */
-        global $DB;
+        /** @var array $CFG_GLPI */
+        global $DB, $CFG_GLPI;
 
         $dbu = new DbUtils();
 
         $ID = $comp->getField('id');
-
-        $items = ['Printer' => _sn('Printer', 'Printers', 2),
-            'Monitor'       => _sn('Monitor', 'Monitors', 2),
-            'Peripheral'    => _sn('Device', 'Devices', 2),
-            'Phone'         => _sn('Phone', 'Phones', 2)];
 
         $info = new Infocom();
 
         $pdf->setColumnsSize(100);
         $pdf->displayTitle('<b>' . __s('Direct connections') . '</b>');
 
-        foreach (array_keys($items) as $type) {
+        foreach ($CFG_GLPI['directconnect_types'] as $type) {
             $item = $dbu->getItemForItemtype($type);
-            if (!$item->canView()) {
+            if (!$item || !$item->canView()) {
                 continue;
             }
             $itemTable = $dbu->getTableForItemType($type);
             $query = [
                 'SELECT' => [
                     'glpi_assets_assets_peripheralassets.id AS assoc_id',
-                    'glpi_assets_assets_peripheralassets.computers_id AS assoc_computers_id',
-                    'glpi_assets_assets_peripheralassets.itemtype',
-                    'glpi_assets_assets_peripheralassets.items_id',
+                    'glpi_assets_assets_peripheralassets.items_id_asset AS assoc_items_id_asset',
+                    'glpi_assets_assets_peripheralassets.itemtype_peripheral',
+                    'glpi_assets_assets_peripheralassets.items_id_peripheral',
                     'glpi_assets_assets_peripheralassets.is_dynamic AS assoc_is_dynamic',
                 ],
                 'FROM' => 'glpi_assets_assets_peripheralassets',
@@ -79,13 +75,14 @@ class PluginPdfComputer_Item extends PluginPdfCommon
                     $itemTable => [
                         'FKEY' => [
                             $itemTable => 'id',
-                            'glpi_assets_assets_peripheralassets' => 'items_id',
+                            'glpi_assets_assets_peripheralassets' => 'items_id_peripheral',
                         ],
                     ],
                 ],
                 'WHERE' => [
-                    'computers_id' => $ID,
-                    'itemtype' => $type,
+                    'itemtype_asset' => $comp->getType(),
+                    'items_id_asset' => $ID,
+                    'itemtype_peripheral' => $type,
                     'glpi_assets_assets_peripheralassets.is_deleted' => 0,
                 ],
             ];
@@ -98,8 +95,7 @@ class PluginPdfComputer_Item extends PluginPdfCommon
             $resultnum = count($result);
             if ($resultnum > 0) {
                 foreach ($result as $row) {
-                    $tID    = $row['items_id'];
-                    $connID = $row['id'];
+                    $tID = $row['items_id_peripheral'];
                     $item->getFromDB($tID);
                     if (!$info->getFromDBforDevice($type, $tID)) {
                         $info->getEmpty();
@@ -177,6 +173,13 @@ class PluginPdfComputer_Item extends PluginPdfCommon
                     case 'Phone':
                         $pdf->displayLine(__s('No phone', 'pdf'));
                         break;
+
+                    default:
+                        $pdf->displayLine(sprintf(
+                            __s('%1$s: %2$s'),
+                            $item->getTypeName(1),
+                            __s('No item to display'),
+                        ));
                 }
             } // No row
         } // each type
@@ -188,18 +191,21 @@ class PluginPdfComputer_Item extends PluginPdfCommon
         /** @var DBmysql $DB */
         global $DB;
 
+        $dbu = new DbUtils();
+
         $ID   = $item->getField('id');
         $type = $item->getType();
 
         $info = new Infocom();
-        $comp = new Computer();
 
         $pdf->setColumnsSize(100);
         $title = '<b>' . __s('Direct connections') . '</b>';
 
         $result = $DB->request(
-            ['FROM' => 'glpi_assets_assets_peripheralassets'] + ['items_id'    => $ID,
-                'itemtype' => $type],
+            ['FROM' => 'glpi_assets_assets_peripheralassets',
+                'WHERE' => ['itemtype_peripheral' => $type,
+                    'items_id_peripheral'         => $ID,
+                    'is_deleted'           => 0]],
         );
         $resultnum = count($result);
 
@@ -209,10 +215,12 @@ class PluginPdfComputer_Item extends PluginPdfCommon
             $pdf->displayTitle($title);
 
             foreach ($result as $row) {
-                $tID    = $row['computers_id'];
-                $connID = $row['id'];
-                $comp->getFromDB($tID);
-                if (!$info->getFromDBforDevice('Computer', $tID)) {
+                $tID  = $row['items_id_asset'];
+                $comp = $dbu->getItemForItemtype($row['itemtype_asset']);
+                if (!$comp || !$comp->getFromDB($tID)) {
+                    continue;
+                }
+                if (!$info->getFromDBforDevice($row['itemtype_asset'], $tID)) {
                     $info->getEmpty();
                 }
 
@@ -251,7 +259,7 @@ class PluginPdfComputer_Item extends PluginPdfCommon
                         sprintf(
                             __s('%1$s: %2$s'),
                             '<b>' . __s('Inventory number') . '</b>',
-                            $item->getField('otherserial'),
+                            $comp->fields['otherserial'],
                         ),
                     );
                 }
@@ -269,13 +277,13 @@ class PluginPdfComputer_Item extends PluginPdfCommon
                 }
                 if ($line2 !== '' && $line2 !== '0') {
                     $pdf->displayText(
-                        '<b>' . sprintf(__s('%1$s: %2$s'), __s('Computer') . '</b>', ''),
+                        '<b>' . sprintf(__s('%1$s: %2$s'), $comp->getTypeName(1) . '</b>', ''),
                         $line1 . "\n" . $line2,
                         2,
                     );
                 } else {
                     $pdf->displayText(
-                        '<b>' . sprintf(__s('%1$s: %2$s'), __s('Computer') . '</b>', ''),
+                        '<b>' . sprintf(__s('%1$s: %2$s'), $comp->getTypeName(1) . '</b>', ''),
                         $line1,
                         1,
                     );

--- a/inc/itemantivirus.class.php
+++ b/inc/itemantivirus.class.php
@@ -30,7 +30,7 @@
  *  --------------------------------------------------------------------------
  */
 
-class PluginPdfComputerAntivirus extends PluginPdfCommon
+class PluginPdfItemAntivirus extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
 
@@ -39,15 +39,15 @@ class PluginPdfComputerAntivirus extends PluginPdfCommon
         $this->obj = ($obj ?: new ItemAntivirus());
     }
 
-    public static function pdfForComputer(PluginPdfSimplePDF $pdf, Computer $item)
+    public static function pdfForItem(PluginPdfSimplePDF $pdf, CommonDBTM $item)
     {
         /** @var DBmysql $DB */
         global $DB;
 
-        $ID = $item->getField('id');
-
-        $result = $DB->request(['FROM' => 'glpi_itemantiviruses'] + ['computers_id' => $ID,
-            'is_deleted'                                                   => 0]);
+        $result = $DB->request(['FROM' => 'glpi_itemantiviruses',
+            'WHERE'                    => ['itemtype' => $item->getType(),
+                'items_id'                            => $item->getID(),
+                'is_deleted'                          => 0]]);
         $number = count($result);
 
         $pdf->setColumnsSize(100);
@@ -74,7 +74,6 @@ class PluginPdfComputerAntivirus extends PluginPdfCommon
                 __s('Expiration date'),
             );
 
-            $antivirus = new ItemAntivirus();
             foreach ($result as $data) {
                 $pdf->displayLine(
                     $data['name'],

--- a/inc/itemvirtualmachine.class.php
+++ b/inc/itemvirtualmachine.class.php
@@ -30,7 +30,7 @@
  *  --------------------------------------------------------------------------
  */
 
-class PluginPdfComputerVirtualMachine extends PluginPdfCommon
+class PluginPdfItemVirtualMachine extends PluginPdfCommon
 {
     public static $rightname = 'plugin_pdf';
 
@@ -39,16 +39,18 @@ class PluginPdfComputerVirtualMachine extends PluginPdfCommon
         $this->obj = ($obj ?: new ItemVirtualMachine());
     }
 
-    public static function pdfForComputer(PluginPdfSimplePDF $pdf, Computer $item)
+    public static function pdfForItem(PluginPdfSimplePDF $pdf, CommonDBTM $item)
     {
         $dbu = new DbUtils();
 
         $ID = $item->getField('id');
 
-        // From ComputerVirtualMachine::showForComputer()
+        // From ItemVirtualMachine::showForAsset()
         $virtualmachines = $dbu->getAllDataFromTable(
             'glpi_itemvirtualmachines',
-            ['computers_id' => $ID],
+            ['WHERE' => ['itemtype' => $item->getType(),
+                'items_id'         => $ID],
+                'ORDER' => 'name'],
         );
         $pdf->setColumnsSize(100);
         $title = '<b>' . __s('List of virtualized environments') . '</b>';
@@ -56,7 +58,7 @@ class PluginPdfComputerVirtualMachine extends PluginPdfCommon
         $number = count($virtualmachines);
 
         if ($number === 0) {
-            $pdf->displayTitle('<b>' . __s('No virtualized environment associated with the computer') . '</b>');
+            $pdf->displayTitle(sprintf(__s('%1$s: %2$s'), $title, __s('No item to display')));
         } else {
             if ($number > $_SESSION['glpilist_limit']) {
                 $title = sprintf(__s('%1$s: %2$s'), $title, $_SESSION['glpilist_limit'] . ' / ' . $number);
@@ -80,10 +82,10 @@ class PluginPdfComputerVirtualMachine extends PluginPdfCommon
 
             foreach ($virtualmachines as $virtualmachine) {
                 $name = '';
-                if ($link_computer = ItemVirtualMachine::findVirtualMachine($virtualmachine)) {
-                    $computer = new Computer();
-                    if ($computer->getFromDB($link_computer)) {
-                        $name = $computer->getName();
+                if ($link_item = ItemVirtualMachine::findVirtualMachine($virtualmachine)) {
+                    $linked = $dbu->getItemForItemtype($virtualmachine['itemtype']);
+                    if ($linked && $linked->getFromDB($link_item)) {
+                        $name = $linked->getName();
                     }
                 }
                 $pdf->displayLine(
@@ -108,10 +110,11 @@ class PluginPdfComputerVirtualMachine extends PluginPdfCommon
             }
         }
 
-        // From ComputerVirtualMachine::showForVirtualMachine()
-        if ($item->fields['uuid']) {
+        // From ItemVirtualMachine::showForVirtualMachine()
+        // The exported item may itself be a guest: look for the host(s) declaring a virtual machine having its UUID.
+        if (!empty($item->fields['uuid'])) {
             $hosts = $dbu->getAllDataFromTable(
-                $item::getTable(),
+                'glpi_itemvirtualmachines',
                 ['RAW'
                  => ['LOWER(uuid)'
                      => ItemVirtualMachine::getUUIDRestrictCriteria($item->fields['uuid']),
@@ -121,21 +124,18 @@ class PluginPdfComputerVirtualMachine extends PluginPdfCommon
 
             if (count($hosts)) {
                 $pdf->setColumnsSize(100);
-                $pdf->displayTitle('<b>' . __s('List of virtualized environments') . '</b>');
+                $pdf->displayTitle('<b>' . __s('List of hosts') . '</b>');
 
                 $pdf->setColumnsSize(26, 37, 37);
-                $pdf->displayTitle(__s('Name'), __s('Operating system'), __s('Entity'));
+                $pdf->displayTitle(__s('Name'), __s('Serial number'), __s('Entity'));
 
-                $computer = new Computer();
                 foreach ($hosts as $host) {
-                    if ($computer->getFromDB($host['id'])) {
+                    $host_item = $dbu->getItemForItemtype($host['itemtype']);
+                    if ($host_item && $host_item->getFromDB($host['items_id'])) {
                         $pdf->displayLine(
-                            $computer->getName(),
-                            Toolbox::stripTags(Dropdown::getDropdownName(
-                                'glpi_operatingsystems',
-                                $computer->getField('operatingsystems_id'),
-                            )),
-                            Dropdown::getDropdownName('glpi_entities', $computer->getEntityID()),
+                            $host_item->getName(),
+                            Toolbox::stripTags((string) $host_item->getField('serial')),
+                            Dropdown::getDropdownName('glpi_entities', $host_item->getEntityID()),
                         );
                     }
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- It fixes !45654
- Several export checkboxes produced nothing in the generated PDF: the tab keys in the plugin's dispatch switches still used pre-GLPI 11 class names, so they never matched. The ticket reported for Tickets on a computer but the same cause affected three more tabs: `Glpi\Asset\Asset_PeripheralAsset$1`, `ItemVirtualMachine$1` and `ItemAntivirus$1`.
- Tab keys fixed : 
  -  Tickets (on assets): `Ticket$1` only -> `Item_Ticket$1` (`Ticket$1` kept for User/Group/SLA)
  -  Connections: `Computer_Item$1` -> `Glpi\Asset\Asset_PeripheralAsset$1`
  -  Virtual machines: `ComputerVirtualMachine$1` -> `ItemVirtualMachine$1`
  - Antivirus: `ComputerAntivirus$1` -> `ItemAntivirus$1`
 
- The handlers behind them were also still querying pre-11 columns, so I did the following column modifications in the queries :

  - `glpi_itemantiviruses` / `glpi_itemvirtualmachines`: `computers_id` → `itemtype + items_id`.
  - `glpi_assets_assets_peripheralassets`: `computers_id`/`itemtype`/`items_id` → `itemtype_asset`/`items_id_asset` `itemtype_peripheral`/`items_id_peripheral`.
  - The VM "hosts" section was querying `glpi_computers` instead of the VM table, which listed the exported computer as its own host; its Operating system column read a field removed from `glpi_computers` and now shows Serial number, matching core.

Renamed  the antivirus and VM handlers and moved them to the common switch because they are no longer Computer-only (GLPI registers those tabs on Phone and on custom asset types ).

`pdfForComputer()` iterates `$CFG_GLPI['directconnect_types'] ` instead of a hardcoded type list to keep the plugin consistent with the core. 